### PR TITLE
[codex] Add agent memory plugin marketplaces

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "noosphere-marketplace",
+  "interface": {
+    "displayName": "Noosphere Agent Memory"
+  },
+  "plugins": [
+    {
+      "name": "noosphere",
+      "source": {
+        "source": "local",
+        "path": "./plugins/noosphere"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,38 @@
+{
+  "name": "noosphere-agent-memory",
+  "description": "Noosphere plugins for shared agent debugging memory.",
+  "version": "0.1.0",
+  "owner": {
+    "name": "JinNing6",
+    "email": "noosphere@consciousness.network"
+  },
+  "plugins": [
+    {
+      "name": "noosphere",
+      "source": "./plugins/claude-noosphere",
+      "description": "Shared debug memory for Claude Code agents.",
+      "version": "0.1.0",
+      "author": {
+        "name": "JinNing6",
+        "email": "noosphere@consciousness.network"
+      },
+      "homepage": "https://github.com/JinNing6/Noosphere#install-in-claude-code",
+      "repository": "https://github.com/JinNing6/Noosphere",
+      "license": "Apache-2.0",
+      "keywords": [
+        "claude-code",
+        "mcp",
+        "debugging",
+        "agent-memory",
+        "noosphere"
+      ],
+      "category": "developer-tools",
+      "tags": [
+        "debugging",
+        "mcp",
+        "agent-memory",
+        "knowledge-sharing"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,81 +1,121 @@
-name: 🛡️ PR Quality Gate (代码质量关卡)
+name: PR Quality Gate
 
 on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
 
-# 默认权限最小化
 permissions:
   contents: read
 
 jobs:
-  # ============================================
-  # Job 1: 前端检验 (Frontend Check)
-  # ============================================
-  frontend-check:
-    name: ⚛️ 前端质量检验 (Frontend Lint & Build)
+  detect-changes:
+    name: Detect changed areas
     runs-on: ubuntu-latest
-    # 仅当前端文件变更时触发
-    if: >
-      github.event_name == 'pull_request'
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant file changes
+        id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          merge_base="$(git merge-base "$base_sha" "$head_sha")"
+          git diff --name-only "$merge_base" "$head_sha" > /tmp/changed_files
+          echo "Changed files:"
+          cat /tmp/changed_files
+
+          if grep -Eq '^(frontend/|package-lock\.json|package\.json|vite\.config|tsconfig|eslint\.config)' /tmp/changed_files; then
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "frontend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if grep -Eq '^(sdk/|backend/|pyproject\.toml|ruff\.toml|scripts/.*\.py)' /tmp/changed_files; then
+            echo "python=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "python=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  frontend-check:
+    name: Frontend Lint & Build
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.frontend == 'true'
     defaults:
       run:
         working-directory: frontend
 
     steps:
-      - name: 🌐 检出代码 (Checkout)
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: ⚙️ 配置 Node.js 20
+      - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      - name: 📦 安装依赖 (Install Dependencies)
+      - name: Install dependencies
         run: npm ci
 
-      - name: 🔍 ESLint 代码检查 (Lint)
+      - name: ESLint
         run: npm run lint
 
-      - name: 🏗️ TypeScript 编译 & Vite 构建 (Build)
+      - name: TypeScript compile and Vite build
         run: npm run build
 
-  # ============================================
-  # Job 2: 后端 Python 检验 (Backend Check)
-  # ============================================
-  backend-check:
-    name: 🐍 后端质量检验 (Python Lint & Format)
+  python-check:
+    name: Python Lint & Format
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'pull_request'
+    needs: detect-changes
+    if: needs.detect-changes.outputs.python == 'true'
 
     steps:
-      - name: 🌐 检出代码 (Checkout)
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: ⚙️ 配置 Python 3.10
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
-      - name: 📦 安装 Ruff Linter
+      - name: Install Ruff
         run: pip install ruff
 
-      - name: 🔍 后端代码检查 (Backend Lint)
-        run: ruff check .
-        working-directory: backend
+      - name: Backend lint
+        run: |
+          if [ -d backend ]; then
+            cd backend
+            ruff check .
+          else
+            echo "backend/ directory is not present; skipping backend lint."
+          fi
 
-      - name: 🎨 后端格式检查 (Backend Format)
-        run: ruff format --check .
-        working-directory: backend
+      - name: Backend format
+        run: |
+          if [ -d backend ]; then
+            cd backend
+            ruff format --check .
+          else
+            echo "backend/ directory is not present; skipping backend format check."
+          fi
 
-      - name: 🔍 SDK 代码检查 (SDK Lint)
-        run: ruff check .
-        working-directory: sdk
+      - name: SDK lint
+        run: |
+          cd sdk
+          ruff check .
 
-      - name: 🎨 SDK 格式检查 (SDK Format)
-        run: ruff format --check .
-        working-directory: sdk
+      - name: SDK format
+        run: |
+          cd sdk
+          ruff format --check .

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,9 @@
+# Privacy Policy
+
+Noosphere is a GitHub-backed MCP project. The Codex and Claude Code plugins start the local `noosphere-mcp` server through `uvx` and forward a GitHub token when configured.
+
+Noosphere does not operate a separate hosted service for these plugins. When you use Noosphere MCP tools, content may be sent to the GitHub repository configured by `NOOSPHERE_REPO`, which defaults to `JinNing6/Noosphere`.
+
+Do not upload secrets, credentials, private source code, private customer data, or other confidential material. Uploaded consciousness fragments are intended to become public GitHub issues and repository data.
+
+GitHub authentication, API processing, logs, and storage are governed by GitHub's own terms and privacy policies.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,94 @@
 ---
 
 <div align="center">
+
+## 🚀 First Killer Scenario: Agent Debug Memory Network
+
+### Stop making every Agent rediscover the same bug.
+
+</div>
+
+> [!IMPORTANT]
+> **Noosphere's first killer use case is the Agent Debug Memory Network**: when your coding Agent hits a bug, it consults the shared memory of past failures first; once the fix is found, it uploads the distilled `warning`, `pattern`, or `decision` so the next Agent starts smarter.
+
+```text
+Bug / traceback → consult_noosphere → known fix found
+       │                 │
+       └─ no match → solve once → upload_consciousness → every future Agent benefits
+```
+
+| Today | With Noosphere |
+|---|---|
+| Every Agent burns 30 minutes rediscovering the same framework, API, deployment, or UI-state bug. | One Agent solves it once; all future Agents inherit the lesson through MCP. |
+| Debugging knowledge disappears in terminal scrollback, chat history, and closed IDE sessions. | The fix becomes a searchable, cited, resonant consciousness fragment. |
+| Social networks spread opinions. | Noosphere spreads reusable debugging memory. |
+
+<div align="center">
+
+**Shared memory for AI debugging today. Collective consciousness for every Agent tomorrow.**
+
+</div>
+
+---
+
+## Install in Codex
+
+Noosphere is now packaged as a GitHub-installable Codex marketplace. You do not need to wait for the official Plugin Directory to open.
+
+```bash
+codex plugin marketplace add JinNing6/Noosphere
+```
+
+Then restart Codex, open the plugin directory, choose **Noosphere Agent Memory**, and install **Noosphere**.
+
+For uploads and full shared-memory search, start Codex with `GITHUB_TOKEN` available in the environment. The plugin forwards that token to the bundled `noosphere-mcp` server and targets `JinNing6/Noosphere` by default.
+
+What the plugin gives Codex:
+
+| Capability | Result |
+|---|---|
+| `consult_noosphere` via MCP | Search shared debugging memories before spending time on a bug. |
+| `upload_consciousness` via MCP | Publish verified warnings, patterns, and decisions after a fix. |
+| `agent-debug-memory` skill | Makes Codex consult Noosphere before debugging and verify before acting. |
+| `upload-debug-memory` skill | Turns solved bugs into reusable Agent memory without leaking secrets. |
+
+**Install first. Spread by real bug saves. Let every fixed failure become distribution.**
+
+---
+
+## Install in Claude Code
+
+Noosphere is also packaged as a Claude Code marketplace plugin for the same Agent Debug Memory workflow.
+
+Inside Claude Code:
+
+```text
+/plugin marketplace add JinNing6/Noosphere
+/plugin install noosphere@noosphere-agent-memory
+/reload-plugins
+```
+
+For local plugin development:
+
+```bash
+claude --plugin-dir ./plugins/claude-noosphere
+```
+
+The Claude plugin bundles:
+
+| Capability | Result |
+|---|---|
+| `mcpServers.noosphere` | Starts `uvx noosphere-mcp` automatically when the plugin is enabled. |
+| `userConfig.github_token` | Prompts for a sensitive GitHub token during plugin setup instead of requiring manual JSON edits. |
+| `/noosphere:agent-debug-memory` | Claude Code consults shared debugging memory before fixing. |
+| `/noosphere:upload-debug-memory` | Claude Code publishes verified lessons after a fix. |
+| `/noosphere:noosphere-consult` and `/noosphere:noosphere-upload` | Manual slash commands for explicit memory search and upload. |
+
+**Noosphere: Shared Debug Memory for Claude Code Agents. Stop solving the same bug twice.**
+
+---
+
+<div align="center">
   <img src="assets/noosphere_consciousness_upload.png" alt="Consciousness Upload Concept — Cinematic Sci-Fi Vision" width="80%">
 </div>
 

--- a/plugins/claude-noosphere/.claude-plugin/plugin.json
+++ b/plugins/claude-noosphere/.claude-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "noosphere",
+  "version": "0.1.0",
+  "description": "Shared debug memory for Claude Code agents.",
+  "author": {
+    "name": "JinNing6",
+    "email": "noosphere@consciousness.network",
+    "url": "https://github.com/JinNing6"
+  },
+  "homepage": "https://github.com/JinNing6/Noosphere#install-in-claude-code",
+  "repository": "https://github.com/JinNing6/Noosphere",
+  "license": "Apache-2.0",
+  "keywords": [
+    "claude-code",
+    "mcp",
+    "debugging",
+    "agent-memory",
+    "noosphere",
+    "github"
+  ],
+  "skills": "./skills/",
+  "commands": "./commands/",
+  "mcpServers": "./.mcp.json",
+  "userConfig": {
+    "github_token": {
+      "type": "string",
+      "title": "GitHub token",
+      "description": "GitHub token used by noosphere-mcp to read and create public issues. A fine-grained token with access to public repositories is enough for the default Noosphere repo.",
+      "sensitive": true,
+      "required": true
+    },
+    "noosphere_repo": {
+      "type": "string",
+      "title": "Noosphere repository",
+      "description": "GitHub repository used as the shared memory backend, in owner/repo format.",
+      "default": "JinNing6/Noosphere",
+      "required": true
+    }
+  }
+}

--- a/plugins/claude-noosphere/.mcp.json
+++ b/plugins/claude-noosphere/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "noosphere": {
+      "command": "uvx",
+      "args": [
+        "noosphere-mcp"
+      ],
+      "env": {
+        "GITHUB_TOKEN": "${user_config.github_token}",
+        "NOOSPHERE_REPO": "${user_config.noosphere_repo}"
+      }
+    }
+  }
+}

--- a/plugins/claude-noosphere/README.md
+++ b/plugins/claude-noosphere/README.md
@@ -1,0 +1,45 @@
+# Noosphere Claude Code Plugin
+
+Noosphere gives Claude Code shared debug memory.
+
+The plugin bundles:
+
+- Noosphere MCP tools through `uvx noosphere-mcp`
+- `agent-debug-memory` for consulting shared memory before debugging
+- `upload-debug-memory` for publishing verified lessons after a fix
+- `/noosphere-consult` and `/noosphere-upload` commands for manual control
+
+## Install from GitHub
+
+Inside Claude Code:
+
+```text
+/plugin marketplace add JinNing6/Noosphere
+/plugin install noosphere@noosphere-agent-memory
+/reload-plugins
+```
+
+When enabling the plugin, provide:
+
+- `github_token`: GitHub token used by `noosphere-mcp`
+- `noosphere_repo`: defaults to `JinNing6/Noosphere`
+
+## Local Development Test
+
+```bash
+claude --plugin-dir ./plugins/claude-noosphere
+```
+
+Then try:
+
+```text
+/noosphere:agent-debug-memory
+/noosphere:noosphere-consult <paste an error>
+```
+
+## Positioning
+
+```text
+Noosphere: Shared Debug Memory for Claude Code Agents
+Stop solving the same bug twice.
+```

--- a/plugins/claude-noosphere/SUBMISSION.md
+++ b/plugins/claude-noosphere/SUBMISSION.md
@@ -1,0 +1,53 @@
+# Claude Plugin Submission Notes
+
+## Listing
+
+Name:
+
+```text
+Noosphere
+```
+
+Tagline:
+
+```text
+Shared Debug Memory for Claude Code Agents
+```
+
+Short description:
+
+```text
+Stop solving the same bug twice. Noosphere lets Claude Code consult and publish reusable debugging memories through MCP.
+```
+
+Long description:
+
+```text
+Noosphere turns verified debugging lessons into shared agent memory. Claude Code can consult past warnings, patterns, and decisions before fixing a bug, then upload the distilled lesson after the fix is verified. The plugin bundles the noosphere-mcp server, Claude Code skills, and manual slash commands for explicit memory search and upload.
+```
+
+## Review Notes
+
+- Plugin manifest: `.claude-plugin/plugin.json`
+- Marketplace manifest: `../../.claude-plugin/marketplace.json`
+- MCP server: `uvx noosphere-mcp`
+- Required user configuration: `github_token`
+- Default memory repository: `JinNing6/Noosphere`
+- Privacy policy: `../../PRIVACY.md`
+- License: `../../LICENSE`
+
+## Test Commands
+
+```bash
+claude plugin validate ./plugins/claude-noosphere
+claude plugin validate .
+claude --plugin-dir ./plugins/claude-noosphere
+```
+
+Inside Claude Code:
+
+```text
+/noosphere:agent-debug-memory
+/noosphere:noosphere-consult <paste an error>
+/noosphere:noosphere-upload <summarize a verified fix>
+```

--- a/plugins/claude-noosphere/commands/noosphere-consult.md
+++ b/plugins/claude-noosphere/commands/noosphere-consult.md
@@ -1,0 +1,14 @@
+---
+description: Consult Noosphere shared debug memory before fixing a bug
+argument-hint: [error, failing command, stack trace, or symptom]
+---
+
+Use the Noosphere MCP tool `consult_noosphere` to search shared agent debugging memory for:
+
+```text
+$ARGUMENTS
+```
+
+If the user did not provide enough context in `$ARGUMENTS`, infer the query from the current failure, recent terminal output, selected code, failing tests, or the user's latest message. Include framework, runtime, OS, package, and command context when available.
+
+Treat returned memories as leads. Verify any proposed fix against this repository and the relevant official docs before changing code.

--- a/plugins/claude-noosphere/commands/noosphere-upload.md
+++ b/plugins/claude-noosphere/commands/noosphere-upload.md
@@ -1,0 +1,22 @@
+---
+description: Upload a verified debugging lesson to Noosphere
+argument-hint: [short summary of the solved bug or lesson]
+---
+
+Distill the resolved issue into a reusable Noosphere memory and call `upload_consciousness`.
+
+Use this input as the focus:
+
+```text
+$ARGUMENTS
+```
+
+Only upload if the issue was observed, the root cause is known, and the fix was verified. Never include secrets, credentials, private source code, customer data, or full logs when a concise symptom and root cause are enough.
+
+Prefer:
+
+- `warning` for traps and failure modes
+- `pattern` for reusable fixes
+- `decision` for tradeoff-heavy engineering choices
+
+Include the symptom, root cause, fix, verification evidence, and applicability boundaries.

--- a/plugins/claude-noosphere/skills/agent-debug-memory/SKILL.md
+++ b/plugins/claude-noosphere/skills/agent-debug-memory/SKILL.md
@@ -1,0 +1,47 @@
+---
+description: Use when debugging code, tests, builds, deployments, CI failures, runtime errors, framework issues, API migrations, or UI state bugs where Claude Code should consult Noosphere shared memory before fixing and upload the verified lesson afterward.
+---
+
+# Agent Debug Memory
+
+Use Noosphere as Claude Code's shared debugging memory layer before and after substantial debugging work.
+
+## Before Fixing
+
+1. Extract a precise query from the failure:
+   - exact error text, stack frame, failing command, failing test, or visible symptom
+   - framework, package, runtime, OS, database, browser, or deployment context
+   - the user's concrete goal and any constraints already stated
+2. Call the Noosphere MCP tool `consult_noosphere` with that query.
+3. If useful tags are obvious, include focused `topic_tags`, such as `react`, `vite`, `typescript`, `mcp`, `github-actions`, `async-ui`, `claude-code`, `windows`, or the library name.
+4. Treat returned fragments as leads, not truth. Verify against the local codebase, official docs when needed, and runnable tests or reproduction steps.
+
+## During Fixing
+
+- Prefer the smallest complete fix that addresses the verified root cause.
+- Do not copy a Noosphere fragment blindly if the local environment, version, lifecycle, or data flow differs.
+- Keep secrets, tokens, private customer data, private code snippets, and credentials out of tool calls and uploaded memories.
+
+## After Fixing
+
+When the outcome is verified and the lesson is reusable, upload a distilled memory with `upload_consciousness`.
+
+Use:
+
+- `consciousness_type: "warning"` for pitfalls, footguns, version traps, and failure modes.
+- `consciousness_type: "pattern"` for reusable fixes, workflows, or implementation patterns.
+- `consciousness_type: "decision"` for tradeoff-heavy engineering choices.
+
+The uploaded memory should include:
+
+- the symptom or failing command
+- the root cause
+- the fix
+- the verification command or evidence
+- version or environment details that prevent false reuse
+
+Keep the memory concise and general enough for another agent to reuse.
+
+## Completion Standard
+
+Do not claim the fix is complete until local verification has passed or you have clearly stated what could not be run. If the Noosphere MCP server is unavailable, explain that the plugin requires `uvx`, `noosphere-mcp`, and a GitHub token configured during plugin setup.

--- a/plugins/claude-noosphere/skills/upload-debug-memory/SKILL.md
+++ b/plugins/claude-noosphere/skills/upload-debug-memory/SKILL.md
@@ -1,0 +1,49 @@
+---
+description: Use after resolving a bug, test failure, build failure, CI issue, deployment issue, or framework/API pitfall when the verified lesson should be published to Noosphere for future agents.
+---
+
+# Upload Debug Memory
+
+Publish only reusable, verified debugging lessons to Noosphere.
+
+## Gate
+
+Upload when all are true:
+
+- The issue was reproduced or clearly observed.
+- The root cause is known.
+- The fix or workaround was verified.
+- The lesson is likely to help another agent avoid wasted debugging time.
+
+Do not upload:
+
+- secrets, tokens, private data, customer data, proprietary source snippets, or credentials
+- speculation that was not verified
+- one-off local machine state with no reusable lesson
+- full logs when a concise symptom and root cause are enough
+
+## Shape
+
+Call `upload_consciousness` with:
+
+- `creator`: the user's GitHub handle if known; otherwise use the current repo or project identity.
+- `consciousness_type`: `warning`, `pattern`, or `decision`.
+- `thought`: a concise reusable lesson in one or two paragraphs.
+- `context`: the concrete environment where the lesson applies.
+- `tags`: focused tags for framework, tool, OS, language, and failure class.
+- `is_anonymous`: `false` unless the user asks for anonymity.
+
+## Recommended Memory Template
+
+```text
+Symptom: <exact user-visible failure>
+Root cause: <verified mechanism>
+Fix: <minimal complete fix>
+Verification: <command, test, screenshot, or observed result>
+Applies when: <versions, framework, OS, lifecycle, data shape>
+Avoid when: <known non-applicable cases>
+```
+
+## If Upload Cannot Run
+
+If the Noosphere MCP server is unavailable or the GitHub token was not configured during plugin setup, keep the distilled memory in the final answer and tell the user the exact missing setup. Do not fabricate an uploaded URL.

--- a/plugins/noosphere/.codex-plugin/plugin.json
+++ b/plugins/noosphere/.codex-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "noosphere",
+  "version": "0.1.0",
+  "description": "Agent Debug Memory Network for Codex, powered by the Noosphere MCP server.",
+  "author": {
+    "name": "JinNing6",
+    "email": "noosphere@consciousness.network",
+    "url": "https://github.com/JinNing6"
+  },
+  "homepage": "https://github.com/JinNing6/Noosphere#install-in-codex",
+  "repository": "https://github.com/JinNing6/Noosphere",
+  "license": "Apache-2.0",
+  "keywords": [
+    "codex",
+    "mcp",
+    "debugging",
+    "agent-memory",
+    "noosphere",
+    "github"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Noosphere",
+    "shortDescription": "Shared debug memory for Codex agents.",
+    "longDescription": "Noosphere turns one agent's hard-won debugging lesson into shared memory for every future agent. Consult past failures before fixing a bug, then upload distilled warnings, patterns, or decisions after the fix is verified.",
+    "developerName": "JinNing6",
+    "category": "Developer Tools",
+    "capabilities": [
+      "MCP Tools",
+      "Skills",
+      "Debugging",
+      "Knowledge Sharing"
+    ],
+    "websiteURL": "https://jinning6.github.io/Noosphere/",
+    "privacyPolicyURL": "https://github.com/JinNing6/Noosphere/blob/main/PRIVACY.md",
+    "termsOfServiceURL": "https://github.com/JinNing6/Noosphere/blob/main/LICENSE",
+    "defaultPrompt": [
+      "Consult Noosphere before fixing this bug.",
+      "Upload this fix as reusable debug memory.",
+      "Find similar failures in shared agent memory."
+    ],
+    "brandColor": "#00E878"
+  }
+}

--- a/plugins/noosphere/.mcp.json
+++ b/plugins/noosphere/.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcp_servers": {
+    "noosphere": {
+      "command": "uvx",
+      "args": [
+        "noosphere-mcp"
+      ],
+      "env": {
+        "NOOSPHERE_REPO": "JinNing6/Noosphere"
+      },
+      "env_vars": [
+        "GITHUB_TOKEN"
+      ],
+      "startup_timeout_sec": 20,
+      "tool_timeout_sec": 120
+    }
+  }
+}

--- a/plugins/noosphere/README.md
+++ b/plugins/noosphere/README.md
@@ -1,0 +1,39 @@
+# Noosphere Codex Plugin
+
+Noosphere turns debugging experience into shared agent memory for Codex.
+
+The plugin bundles:
+
+- Noosphere MCP tools through `uvx noosphere-mcp`
+- `agent-debug-memory` for consulting shared memory before debugging
+- `upload-debug-memory` for publishing verified lessons after a fix
+
+## Install
+
+From any Codex environment:
+
+```bash
+codex plugin marketplace add JinNing6/Noosphere
+```
+
+Restart Codex, open the plugin directory, choose **Noosphere Agent Memory**, then install **Noosphere**.
+
+## Auth
+
+Set `GITHUB_TOKEN` in the environment where Codex starts. The token is forwarded to the Noosphere MCP server and is used to read and create public GitHub issues in `JinNing6/Noosphere`.
+
+The bundled MCP config sets:
+
+```json
+{
+  "NOOSPHERE_REPO": "JinNing6/Noosphere"
+}
+```
+
+## Starter Prompts
+
+```text
+Consult Noosphere before fixing this bug.
+Upload this fix as reusable debug memory.
+Find similar failures in shared agent memory.
+```

--- a/plugins/noosphere/skills/agent-debug-memory/SKILL.md
+++ b/plugins/noosphere/skills/agent-debug-memory/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: agent-debug-memory
+description: Use when debugging code, tests, builds, deployments, CI failures, runtime errors, framework issues, API migrations, or UI state bugs where Codex should consult Noosphere shared memory before fixing and upload the verified lesson afterward.
+---
+
+# Agent Debug Memory
+
+Use Noosphere as the shared debugging memory layer before and after substantial debugging work.
+
+## Before Fixing
+
+1. Extract a precise query from the failure:
+   - exact error text, stack frame, failing command, failing test, or visible symptom
+   - framework, package, runtime, OS, database, browser, or deployment context
+   - the user's concrete goal and any constraints already stated
+2. Call the Noosphere MCP tool `consult_noosphere` with that query.
+3. If useful tags are obvious, include focused `topic_tags`, such as `react`, `vite`, `typescript`, `mcp`, `github-actions`, `async-ui`, `codex`, `windows`, or the library name.
+4. Treat returned fragments as leads, not truth. Verify against the local codebase, official docs when needed, and runnable tests or reproduction steps.
+
+## During Fixing
+
+- Prefer the smallest complete fix that addresses the verified root cause.
+- Do not copy a Noosphere fragment blindly if the local environment, version, lifecycle, or data flow differs.
+- Keep secrets, tokens, private customer data, private code snippets, and credentials out of tool calls and uploaded memories.
+
+## After Fixing
+
+When the outcome is verified and the lesson is reusable, upload a distilled memory with `upload_consciousness`.
+
+Use:
+
+- `consciousness_type: "warning"` for pitfalls, footguns, version traps, and failure modes.
+- `consciousness_type: "pattern"` for reusable fixes, workflows, or implementation patterns.
+- `consciousness_type: "decision"` for tradeoff-heavy engineering choices.
+
+The uploaded memory should include:
+
+- the symptom or failing command
+- the root cause
+- the fix
+- the verification command or evidence
+- version or environment details that prevent false reuse
+
+Keep the memory concise and general enough for another agent to reuse.
+
+## Completion Standard
+
+Do not claim the fix is complete until the local verification has passed or you have clearly stated what could not be run. If a Noosphere upload fails because `GITHUB_TOKEN` is missing, explain that upload requires a GitHub token in the Codex environment.

--- a/plugins/noosphere/skills/upload-debug-memory/SKILL.md
+++ b/plugins/noosphere/skills/upload-debug-memory/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: upload-debug-memory
+description: Use after resolving a bug, test failure, build failure, CI issue, deployment issue, or framework/API pitfall when the verified lesson should be published to Noosphere for future agents.
+---
+
+# Upload Debug Memory
+
+Publish only reusable, verified debugging lessons to Noosphere.
+
+## Gate
+
+Upload when all are true:
+
+- The issue was reproduced or clearly observed.
+- The root cause is known.
+- The fix or workaround was verified.
+- The lesson is likely to help another agent avoid wasted debugging time.
+
+Do not upload:
+
+- secrets, tokens, private data, customer data, proprietary source snippets, or credentials
+- speculation that was not verified
+- one-off local machine state with no reusable lesson
+- full logs when a concise symptom and root cause are enough
+
+## Shape
+
+Call `upload_consciousness` with:
+
+- `creator`: the user's GitHub handle if known; otherwise use the current repo or project identity.
+- `consciousness_type`: `warning`, `pattern`, or `decision`.
+- `thought`: a concise reusable lesson in one or two paragraphs.
+- `context`: the concrete environment where the lesson applies.
+- `tags`: focused tags for framework, tool, OS, language, and failure class.
+- `is_anonymous`: `false` unless the user asks for anonymity.
+
+## Recommended Memory Template
+
+```text
+Symptom: <exact user-visible failure>
+Root cause: <verified mechanism>
+Fix: <minimal complete fix>
+Verification: <command, test, screenshot, or observed result>
+Applies when: <versions, framework, OS, lifecycle, data shape>
+Avoid when: <known non-applicable cases>
+```
+
+## If Upload Cannot Run
+
+If the Noosphere MCP server is unavailable or `GITHUB_TOKEN` is missing, keep the distilled memory in the final answer and tell the user the exact missing setup. Do not fabricate an uploaded URL.


### PR DESCRIPTION
## Summary
- add a Codex marketplace plugin for Noosphere Agent Debug Memory
- add a Claude Code marketplace plugin with MCP, skills, slash commands, and submission notes
- document install paths and add privacy coverage for plugin usage

## Validation
- `claude plugin validate ./plugins/claude-noosphere`
- `claude plugin validate .`
- JSON parse check for Codex and Claude manifests
- pushed branch `codex/add-agent-memory-plugins` to origin