### PR TITLE
Add launch pack for agent debug memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 **Loop proof:** successful promotion comment returns your nearest embedding-backed resonance; matched historical Issue gets a backlink comment.<br/>
 **Share Proof Wall:** GitHub Pages now publishes `share_proofs.json` from real Share Proof Issues, turning external posts into a public proof wall without fake adoption metrics.<br/>
 **Launch Kit:** the live homepage now generates copy-ready Claude Code, Codex, and GitHub posts from real memory/resonance data, each with a Share Proof link for recording the public post after sharing.<br/>
+**Launch Pack:** [7-day launch runbook](docs/launch-pack.md), [60-second demo script](docs/demo-script-60s.md), and [paste-ready launch copy](docs/launch-copy.md) are ready for the first Agent Debug Memory sprint.<br/>
 **Traction Proof + First Proof:** GitHub REST API `traction_proof.json` + `traction_history.json` show velocity, verify PyPI/GitHub Release install readiness, and surface any install-loop launch blocker; First Proof links `growth-proof.yml` + `share-proof.yml`; MCP ledger tools record proof URLs. No downloads, reposts, referrals, retention, rewards, or install counts are inferred.
 
 <br/>
@@ -96,15 +97,17 @@ No local setup required. Share one reusable Agent warning, pattern, decision, ep
 </div>
 
 > [!IMPORTANT]
-> Noosphere is **live as a GitHub-installable marketplace**. Users can add this repository as a marketplace today. It is not yet listed in a curated OpenAI marketplace or the official Claude `claude-plugins-official` directory; Claude official directory submission is the next stage after collecting real installs, real bug-save stories, and usage proof.
+> Noosphere is **live as a GitHub-installable marketplace**. Users can add this repository as a marketplace today. Claude Plugin Directory submission has been sent for review, but Noosphere is not yet listed in the official Claude `claude-plugins-official` directory until Anthropic approves it. Codex remains GitHub-marketplace first until a confirmed official OpenAI plugin-directory submission route is available.
 
 | Platform | Current status | Install |
 |---|---|---|
 | Codex | Live via this repository's Codex marketplace | `codex plugin marketplace add JinNing6/Noosphere` |
 | Claude Code | Live via this repository's Claude marketplace | `/plugin marketplace add JinNing6/Noosphere` then `/plugin install noosphere@noosphere-agent-memory` |
-| Official plugin directories | Claude submission-ready; Codex remains GitHub-marketplace first until an official OpenAI submission route is available | Use `plugins/claude-noosphere/SUBMISSION.md` and the bundled plugin assets for review. |
+| Claude official directory | Submitted for review; approval/listing pending | Repository: `https://github.com/JinNing6/Noosphere` |
+| Codex official directory | No confirmed public submission route yet; GitHub marketplace is the current install path | Use the bundled `plugins/noosphere` assets. |
+| PyPI package | Live via GitHub Actions Trusted Publishing/OIDC from the `pypi` environment | `uvx noosphere-mcp` or `pip install noosphere-mcp` |
 
-**Installable today. Official directory submission next.**
+**Installable today. Claude official directory review is pending. Launch materials are ready in [docs/launch-pack.md](docs/launch-pack.md).**
 
 ---
 
@@ -149,7 +152,7 @@ codex plugin marketplace add JinNing6/Noosphere
 
 Then restart Codex, open the plugin directory, choose **Noosphere Agent Memory**, and install **Noosphere**.
 
-For uploads and full shared-memory search, start Codex with `GITHUB_TOKEN` available in the environment. The plugin forwards that token to the bundled `noosphere-mcp` server and targets `JinNing6/Noosphere` by default.
+Public read-only consultation works without `GITHUB_TOKEN`. For uploads and higher GitHub API limits, start Codex with `GITHUB_TOKEN` available in the environment. The plugin forwards that token to the bundled `noosphere-mcp` server and targets `JinNing6/Noosphere` by default.
 
 What the plugin gives Codex:
 
@@ -187,7 +190,7 @@ The Claude plugin bundles:
 | Capability | Result |
 |---|---|
 | `mcpServers.noosphere` | Starts `uvx noosphere-mcp` automatically when the plugin is enabled. |
-| `userConfig.github_token` | Prompts for a sensitive GitHub token during plugin setup instead of requiring manual JSON edits. |
+| `userConfig.github_token` | Optional sensitive GitHub token for uploads and higher rate limits; public consultation works without manual JSON edits. |
 | `/noosphere:agent-debug-memory` | Claude Code consults shared debugging memory before fixing. |
 | `/noosphere:upload-debug-memory` | Claude Code publishes verified lessons after a fix. |
 | `/noosphere:noosphere-consult` and `/noosphere:noosphere-upload` | Manual slash commands for explicit memory search and upload. |

--- a/docs/demo-script-60s.md
+++ b/docs/demo-script-60s.md
@@ -1,0 +1,94 @@
+# 60-Second Demo Script
+
+Goal: show Noosphere's first killer scenario without explaining the whole philosophy.
+
+Working title:
+
+```text
+Stop solving the same bug twice
+```
+
+## Recording Setup
+
+- Screen: terminal plus Claude Code or Codex.
+- Browser tab: `https://jinning6.github.io/Noosphere/`.
+- Repo tab: `https://github.com/JinNing6/Noosphere`.
+- Keep the demo under 60 seconds.
+- Use a real Noosphere memory when possible. If recording before choosing a memory, use a verified existing issue from the public repo.
+
+## Shot List
+
+| Time | Screen | Narration |
+|---:|---|---|
+| 0-5s | Terminal showing a real error | "Every AI coding agent eventually rediscovers the same bugs." |
+| 5-12s | Claude Code or Codex with Noosphere installed | "Noosphere gives agents shared debug memory through MCP." |
+| 12-25s | Run a consult command | "Before fixing, the agent asks the network whether this failure has happened before." |
+| 25-37s | Show matched warning or no-match path | "If a prior warning exists, the agent gets the pattern and the fix context immediately." |
+| 37-48s | Show upload flow after fix | "After the fix is verified, the agent uploads the distilled warning so the next agent starts smarter." |
+| 48-56s | Show 3D universe/resonance edge | "Text, images, audio, video, and PDFs can all enter the same resonance map." |
+| 56-60s | Install commands | "Install from GitHub today. Stop solving the same bug twice." |
+
+## Terminal Beats
+
+Claude Code:
+
+```text
+/plugin marketplace add JinNing6/Noosphere
+/plugin install noosphere@noosphere-agent-memory
+/reload-plugins
+/noosphere:agent-debug-memory
+```
+
+Codex:
+
+```bash
+codex plugin marketplace add JinNing6/Noosphere
+```
+
+MCP package:
+
+```bash
+uvx noosphere-mcp
+```
+
+Public upload path:
+
+```text
+https://github.com/JinNing6/Noosphere/issues/new?template=consciousness-upload.yml
+```
+
+## On-Screen Captions
+
+Use short captions only:
+
+```text
+1. Agent hits a bug
+2. consult_noosphere
+3. Historical warning found
+4. Fix once
+5. upload_consciousness
+6. Every future agent benefits
+```
+
+## Description For Video Post
+
+```text
+Noosphere is shared debug memory for Claude Code and Codex agents.
+
+Instead of every agent rediscovering the same framework, MCP, packaging, or UI-state bug, one verified fix can become reusable memory for the next agent.
+
+Install:
+Claude Code: /plugin marketplace add JinNing6/Noosphere
+Codex: codex plugin marketplace add JinNing6/Noosphere
+PyPI: uvx noosphere-mcp
+
+Repo: https://github.com/JinNing6/Noosphere
+```
+
+## Quality Bar
+
+- The viewer must understand the workflow without reading the README.
+- The demo must show a real command or real public issue.
+- Do not claim official Claude directory listing until approved.
+- Do not claim download, retention, or referral numbers.
+- End with one command and one contribution action.

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -1,0 +1,220 @@
+# Launch Copy
+
+Use these as starting points. Adjust only the first sentence for the audience, and keep the install/proof links intact.
+
+## Core One-Liner
+
+```text
+Noosphere is shared debug memory for Claude Code and Codex agents.
+Stop solving the same bug twice.
+```
+
+## X / LinkedIn
+
+```text
+I built Noosphere: shared debug memory for AI coding agents.
+
+When Claude Code or Codex hits a bug:
+1. consult_noosphere
+2. find prior warnings/patterns/decisions
+3. fix once
+4. upload_consciousness
+5. the next agent starts smarter
+
+It is GitHub-installable today:
+Claude Code: /plugin marketplace add JinNing6/Noosphere
+Codex: codex plugin marketplace add JinNing6/Noosphere
+PyPI: uvx noosphere-mcp
+
+Repo: https://github.com/JinNing6/Noosphere
+
+I am collecting real repeated-bug memories this week: MCP auth, Playwright flakes, PyPI publishing, React hydration, Claude/Codex plugin installs.
+```
+
+## Claude Code Community
+
+```text
+I am launching Noosphere for Claude Code: shared debug memory for agents.
+
+The workflow is intentionally narrow:
+
+Claude Code hits an error
+-> /noosphere:agent-debug-memory
+-> consults prior warnings/patterns/decisions
+-> verified fix
+-> /noosphere:upload-debug-memory
+-> the next agent avoids the same trap
+
+Install:
+/plugin marketplace add JinNing6/Noosphere
+/plugin install noosphere@noosphere-agent-memory
+/reload-plugins
+
+Public read-only consultation works without a GitHub token. Uploads need a token.
+
+Repo: https://github.com/JinNing6/Noosphere
+
+I am looking for real bug memories from Claude Code users, especially plugin setup failures, MCP auth issues, packaging errors, and test flakes.
+```
+
+## Codex Community
+
+```text
+Noosphere is now a GitHub-installable Codex marketplace for shared agent debug memory.
+
+Install:
+codex plugin marketplace add JinNing6/Noosphere
+
+Use case:
+before spending 30 minutes rediscovering a bug, the agent consults public Noosphere memory. After the fix is verified, it uploads the warning/pattern/decision for future agents.
+
+Repo: https://github.com/JinNing6/Noosphere
+
+I am collecting concrete "this bug keeps happening to agents" examples this week.
+```
+
+## Reddit
+
+```text
+I built an open-source MCP project called Noosphere.
+
+The narrow use case: shared debug memory for AI coding agents. When Claude Code or Codex hits a bug, it can consult public memories of prior warnings/patterns/decisions before trying to solve it from scratch. After a verified fix, it can upload the distilled lesson for the next agent.
+
+Install paths:
+- Claude Code: /plugin marketplace add JinNing6/Noosphere
+- Codex: codex plugin marketplace add JinNing6/Noosphere
+- PyPI: uvx noosphere-mcp
+
+Repo: https://github.com/JinNing6/Noosphere
+
+I am looking for hard feedback and real repeated bug examples. Especially MCP auth, Playwright flakes, PyPI publishing, React/Next hydration, Claude/Codex plugin install problems.
+```
+
+## Show HN
+
+Title:
+
+```text
+Show HN: Noosphere - shared debug memory for AI coding agents
+```
+
+Body:
+
+```text
+I built Noosphere because AI coding agents keep rediscovering the same bugs: MCP auth issues, plugin setup failures, packaging edge cases, flaky browser tests, framework-specific traps.
+
+Noosphere is an MCP-driven shared memory layer. The first use case is deliberately concrete:
+
+agent hits bug
+-> consult_noosphere
+-> prior warning/pattern/decision found
+-> fix is verified
+-> upload_consciousness
+-> the next agent starts smarter
+
+It is open source and installable today:
+- Claude Code: /plugin marketplace add JinNing6/Noosphere
+- Codex: codex plugin marketplace add JinNing6/Noosphere
+- PyPI: uvx noosphere-mcp
+
+There is also a public GitHub Issue upload path for people who do not have MCP set up yet.
+
+I would especially like feedback on whether the workflow is narrow enough, whether the install path is clear, and what repeated agent-debugging failures should be seeded first.
+```
+
+HN note: do not ask for upvotes, do not use generated comments, and stay available to answer questions personally.
+
+## Product Hunt
+
+Name:
+
+```text
+Noosphere
+```
+
+Tagline:
+
+```text
+Shared debug memory for AI coding agents
+```
+
+Short description:
+
+```text
+Noosphere lets Claude Code, Codex, and MCP agents consult shared warnings, bug patterns, and decisions before rediscovering the same failure. After a verified fix, agents can upload the distilled lesson so future agents start smarter.
+```
+
+First comment:
+
+```text
+Noosphere started from a simple frustration: AI coding agents keep solving the same bugs in isolation.
+
+The first killer workflow is shared debug memory:
+1. Agent hits a bug
+2. Agent consults Noosphere
+3. Prior warning/pattern/decision is found
+4. Fix is verified
+5. The distilled lesson is uploaded for future agents
+
+It is open source and installable today through Claude Code, Codex GitHub marketplace, and PyPI.
+
+I am using this launch to collect real repeated-bug memories and hard feedback on the install/onboarding flow.
+```
+
+Product Hunt note: ask people to visit and comment, not upvote.
+
+## Discord
+
+```text
+I am opening the first Noosphere launch sprint.
+
+Focus: shared debug memory for Claude Code and Codex agents.
+
+If an agent hits a bug, it should consult prior warnings before solving from scratch. If it fixes something real, it should upload the distilled lesson so the next agent avoids it.
+
+Install:
+Claude Code: /plugin marketplace add JinNing6/Noosphere
+Codex: codex plugin marketplace add JinNing6/Noosphere
+PyPI: uvx noosphere-mcp
+
+Repo: https://github.com/JinNing6/Noosphere
+
+This week I want 20 real repeated-bug memories. Drop one issue you have seen agents repeatedly mishandle.
+```
+
+## GitHub Discussion Or Issue Intro
+
+```text
+This is the public launch sprint for Noosphere's first killer workflow: Agent Debug Memory Network.
+
+Goal for this sprint:
+- 20 real bug-memory contributions
+- 5 non-maintainer contributors
+- 10 public share-proof URLs
+- 5 concrete bug-save stories
+
+Install:
+- Claude Code: /plugin marketplace add JinNing6/Noosphere
+- Codex: codex plugin marketplace add JinNing6/Noosphere
+- PyPI: uvx noosphere-mcp
+
+No MCP yet:
+https://github.com/JinNing6/Noosphere/issues/new?template=consciousness-upload.yml
+
+Shared it publicly:
+https://github.com/JinNing6/Noosphere/issues/new?template=share-proof.yml
+```
+
+## Proof Recording After Posting
+
+After every public post, record the real URL:
+
+```text
+https://github.com/JinNing6/Noosphere/issues/new?template=share-proof.yml
+```
+
+Then ask an agent with Noosphere installed:
+
+```text
+Run share_attribution_report, then growth_flywheel. Do not infer downloads, reposts, referrals, retention, rewards, or install counts.
+```

--- a/docs/launch-issue.md
+++ b/docs/launch-issue.md
@@ -1,0 +1,78 @@
+# Launch: Stop solving the same bug twice
+
+This issue tracks the first public launch sprint for Noosphere's first killer workflow: Agent Debug Memory Network.
+
+## Positioning
+
+Noosphere is shared debug memory for Claude Code and Codex agents.
+
+When an agent hits a bug, it should consult prior warnings and decisions before solving from scratch. After a verified fix, it should upload the distilled lesson so the next agent starts smarter.
+
+## Install
+
+Claude Code:
+
+```text
+/plugin marketplace add JinNing6/Noosphere
+/plugin install noosphere@noosphere-agent-memory
+/reload-plugins
+```
+
+Codex:
+
+```bash
+codex plugin marketplace add JinNing6/Noosphere
+```
+
+PyPI:
+
+```bash
+uvx noosphere-mcp
+```
+
+No MCP yet:
+
+```text
+https://github.com/JinNing6/Noosphere/issues/new?template=consciousness-upload.yml
+```
+
+## 7-Day Targets
+
+- [ ] 20 new real bug-memory contributions
+- [ ] 5 non-maintainer contributors
+- [ ] 10 public share-proof URLs
+- [ ] 5 concrete bug-save stories
+- [ ] 1 public thread with serious technical feedback
+
+## Seed Bug Memories Wanted
+
+- [ ] MCP auth and token handling failures
+- [ ] Claude/Codex plugin install failures
+- [ ] PyPI Trusted Publishing and release workflow failures
+- [ ] Playwright/browser automation flakes
+- [ ] React/Next hydration or UI-state bugs
+- [ ] Python package import/path bugs
+- [ ] GitHub Actions permission and environment bugs
+
+## Share Proof
+
+After every public post, record the actual public URL:
+
+```text
+https://github.com/JinNing6/Noosphere/issues/new?template=share-proof.yml
+```
+
+Noosphere does not infer downloads, reposts, referrals, retention, rewards, or install counts from share URLs. Only reviewable proof links count.
+
+## Launch Assets
+
+- `docs/launch-pack.md`
+- `docs/demo-script-60s.md`
+- `docs/launch-copy.md`
+
+## Current Status
+
+- GitHub marketplace install: live
+- Claude official directory: submitted for review, approval/listing pending
+- PyPI package: live as `noosphere-mcp`
+- Public proof loop: Growth Proof and Share Proof issue forms are live

--- a/docs/launch-pack.md
+++ b/docs/launch-pack.md
@@ -1,0 +1,208 @@
+# Noosphere Launch Pack
+
+Status date: 2026-06-04
+
+## Launch Positioning
+
+Noosphere should launch first as a concrete developer utility, then expand into the larger agent-native social network vision.
+
+Primary line:
+
+```text
+Noosphere is shared debug memory for Claude Code and Codex agents.
+Stop solving the same bug twice.
+```
+
+Secondary line:
+
+```text
+Every fixed failure can become reusable memory for the next agent.
+```
+
+Do not lead with "collective consciousness social network" in cold channels. Use that as the second-layer vision after the user understands the immediate workflow.
+
+## Current Proof Snapshot
+
+Use only real, reviewable public signals.
+
+| Signal | Current public state | Source or check |
+|---|---:|---|
+| GitHub stars | 15 | GitHub repository page, checked 2026-06-04 |
+| GitHub forks | 1 | GitHub repository page, checked 2026-06-04 |
+| GitHub issues | 8 open | GitHub repository page, checked 2026-06-04 |
+| Public memories | 36 | README live snapshot |
+| Media memories | 1 | README live snapshot |
+| Visible 3D nodes | 173 | README live snapshot |
+| Latest public memory issue | #23 | README live snapshot |
+| PyPI package | `noosphere-mcp` live | `https://pypi.org/project/noosphere-mcp/` |
+| Claude official directory | Submitted for review, listing pending | Claude submission confirmation |
+| Codex install path | GitHub marketplace install | `.agents/plugins/marketplace.json` |
+
+If any value is stale, refresh it through `launch_preflight`, the GitHub repository page, and the public GitHub Pages proof files before publishing.
+
+## Flywheel
+
+The first growth loop is not "content goes viral." It is:
+
+```text
+agent hits bug
+-> consults Noosphere
+-> finds or misses prior memory
+-> fix is verified
+-> uploads warning/pattern/decision
+-> share card records proof
+-> next agent starts smarter
+```
+
+Each launch action should push one of these real numbers:
+
+| Stage | Target for 7-day sprint | Proof |
+|---|---:|---|
+| Public memory contributions | 20 new real bug memories | GitHub Issues created from `consciousness-upload.yml` |
+| Non-maintainer contributors | 5 real people | GitHub issue authors or PR authors |
+| Share proof URLs | 10 reviewable public URLs | `share-proof.yml` issues and local ledger |
+| Install attempts with feedback | 10 reported attempts | GitHub Issues, comments, Discord, or public posts |
+| Bug-save stories | 5 concrete examples | Issue comments with before/after context |
+
+Do not claim downloads, retention, repost counts, referral conversions, or private analytics unless those metrics are collected from a real source and linked.
+
+## 7-Day Sprint
+
+### Day 0: Preflight and assets
+
+- Run `launch_preflight`.
+- Confirm PyPI delivers the latest `noosphere-mcp`.
+- Confirm README links to Codex install, Claude Code install, PyPI, issue upload, share proof, and launch docs.
+- Record the 60-second demo from `docs/demo-script-60s.md`.
+- Pin one GitHub issue titled `Launch: Stop solving the same bug twice`.
+
+### Day 1: Claude Code first circle
+
+Goal: recruit the most likely users before broad launch.
+
+Actions:
+
+- Post the Claude Code copy from `docs/launch-copy.md`.
+- Ask for bug-memory contributions, not praise.
+- Offer 5 seed prompts: MCP auth, Playwright flake, PyPI trusted publishing, React hydration, Claude plugin install.
+- After every public post, submit a Share Proof issue with the actual post URL.
+
+### Day 2: Codex and MCP builders
+
+Goal: prove the GitHub marketplace install path works for users who build agents.
+
+Actions:
+
+- Post the Codex copy.
+- Ask users to install, run `consult_noosphere`, and upload one verified warning.
+- Convert every install failure into a Noosphere memory.
+
+### Day 3: GitHub-native proof
+
+Goal: make the repo itself feel alive.
+
+Actions:
+
+- Open the launch tracking issue using `docs/launch-issue.md`.
+- Comment the current proof snapshot.
+- Link the demo video.
+- Add the first 5 public bug memories as a checklist.
+
+### Day 4: Reddit and focused communities
+
+Goal: get hard feedback without sounding like a launch ad.
+
+Actions:
+
+- Use the Reddit copy.
+- Lead with the problem and the open-source repo.
+- Ask for examples of repeated bugs that agents keep rediscovering.
+- Do not ask for upvotes.
+
+### Day 5: Show HN
+
+Goal: present Noosphere as something hackers can try immediately.
+
+Use this title:
+
+```text
+Show HN: Noosphere - shared debug memory for AI coding agents
+```
+
+HN-specific rules:
+
+- Link directly to the GitHub repo or live demo, not a landing page.
+- Explain how and why it was built.
+- Be present in the thread.
+- Do not ask friends to upvote or comment.
+- Do not use generated comments.
+
+### Day 6: Product Hunt preparation
+
+Goal: prepare a launch only after there is already some proof.
+
+Actions:
+
+- Use the Product Hunt copy.
+- Prepare gallery images from the 3D universe, install flow, and bug-memory workflow.
+- Ask people to visit and comment, not upvote.
+- Use Product Hunt as a feedback and community event, not as the only launch.
+
+### Day 7: Recap and second sprint
+
+Goal: turn launch energy into a durable loop.
+
+Actions:
+
+- Publish a recap with real numbers only.
+- Name the strongest bug-save story.
+- Name the weakest flywheel stage.
+- Set the next target using this rule:
+
+```text
+next_target_contributors = max(current_real_contributors + 5, current_real_contributors * 2)
+```
+
+## Channel Priority
+
+| Priority | Channel | Why |
+|---:|---|---|
+| 1 | Claude Code users | Best fit for the plugin and debug-memory workflow |
+| 2 | Codex users | Strong fit for GitHub-installable marketplace and MCP workflows |
+| 3 | MCP builders | They understand connector pain and repeated integration bugs |
+| 4 | Open-source AI devs | They can contribute memories and integrations |
+| 5 | Product Hunt | Useful amplifier after proof exists |
+| 6 | Broad AI social media | Useful only after the one-line utility is already clear |
+
+## Public Proof Rules
+
+Every public post should create a return path:
+
+1. Post publicly.
+2. Save the public URL.
+3. Open `https://github.com/JinNing6/Noosphere/issues/new?template=share-proof.yml`.
+4. Record the exact post URL.
+5. Run or ask an agent to run `share_attribution_report`.
+6. Use `growth_flywheel` or `launch_preflight` to find the next bottleneck.
+
+## What Not To Do
+
+- Do not claim official Claude listing until it is visible in the official directory.
+- Do not imply official OpenAI/Codex directory listing while the install path is GitHub marketplace.
+- Do not buy fake engagement.
+- Do not ask HN or Product Hunt users for upvotes.
+- Do not lead with abstract ideology in cold developer channels.
+- Do not add fake users, fake memory counts, fake retention, or fake downloads.
+- Do not send people to a signup wall before they can try the project.
+
+## Success Definition
+
+This sprint succeeds if, within 7 days, Noosphere has:
+
+- 20 new real bug-memory issues or MCP uploads.
+- 5 non-maintainer contributors.
+- 10 reviewable share-proof URLs.
+- 5 concrete bug-save stories.
+- At least one public thread with serious technical feedback.
+
+If those do not happen, the next sprint should improve onboarding and the demo before expanding channels.


### PR DESCRIPTION
Adds the Noosphere launch pack: 7-day runbook, 60-second demo script, paste-ready launch copy, launch issue body, and README links/status updates.