### PR TITLE
Add zero-setup Living Skill validation kit

### DIFF
--- a/.github/ISSUE_TEMPLATE/validate-skill.yml
+++ b/.github/ISSUE_TEMPLATE/validate-skill.yml
@@ -1,0 +1,46 @@
+name: Validate a reusable Agent fix
+description: Run one deterministic command and submit independent evidence for a Living Skill.
+title: "Skill validation: "
+labels:
+  - consciousness
+  - ephemeral
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Validate Living Skill #001
+
+        Run this command in a terminal. It creates an isolated fixture, reproduces the failure, verifies the fix, and prints a canonical evidence block:
+
+        ```bash
+        uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
+        ```
+
+        No project, GitHub token, MCP configuration, or package-index account is required. Review the generated evidence before submitting it.
+
+  - type: textarea
+    id: generated_validation_evidence
+    attributes:
+      label: Generated validation evidence
+      description: Paste the complete output block, including the CONSCIOUSNESS_PAYLOAD markers.
+      placeholder: "<!-- CONSCIOUSNESS_PAYLOAD_START --> ... <!-- CONSCIOUSNESS_PAYLOAD_END -->"
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: validator_notes
+    attributes:
+      label: Validator notes
+      description: Optional environment details or observations that are not already present in the generated evidence.
+      placeholder: "Optional: I also verified..."
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: declaration
+    attributes:
+      label: Independent validation declaration
+      options:
+        - label: I ran the command independently, reviewed the generated evidence, and removed any sensitive information before submission.
+          required: true

--- a/.github/scripts/consciousness-payload.test.cjs
+++ b/.github/scripts/consciousness-payload.test.cjs
@@ -34,6 +34,63 @@ test("extracts the canonical MCP marker payload", () => {
   assert.deepEqual(result.payload, validPayload);
 });
 
+test("extracts canonical evidence pasted through the dedicated Skill validation form", () => {
+  const validationPayload = {
+    ...validPayload,
+    target_skill: "public-artifact-runtime-smoke-gate",
+    evidence: {
+      symptom: "Source invocation passes while the installed artifact entry point fails.",
+      root_cause: "The built artifact omitted the runtime module.",
+      fix: "Install and execute the exact built artifact in an isolated environment.",
+      verification: "Failing artifact exited 1 and the fixed artifact exited 0.",
+      applies_when: "A packaged CLI may differ from its source tree.",
+      avoid_when: "The exact artifact was not resolved.",
+      test_commands: [
+        "uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate",
+      ],
+      source_urls: [
+        "https://github.com/JinNing6/Noosphere/issues/37",
+        "https://github.com/JinNing6/Noosphere/tree/main/examples/reproductions/public-artifact-runtime-smoke-gate",
+      ],
+    },
+  };
+  const body = [
+    "### Generated validation evidence",
+    "",
+    "```markdown",
+    "<!-- CONSCIOUSNESS_PAYLOAD_START -->",
+    "```json",
+    JSON.stringify(validationPayload, null, 2),
+    "```",
+    "<!-- CONSCIOUSNESS_PAYLOAD_END -->",
+    "```",
+    "",
+    "### Independent validation declaration",
+    "",
+    "- [x] I ran the command independently.",
+  ].join("\n");
+
+  const result = extractConsciousnessPayload(body);
+
+  assert.equal(result.source, "mcp-marker");
+  assert.deepEqual(result.payload, validationPayload);
+});
+
+test("dedicated Skill validation form exposes one command and the canonical evidence field", () => {
+  const formPath = path.join(__dirname, "..", "ISSUE_TEMPLATE", "validate-skill.yml");
+  const form = fs.readFileSync(formPath, "utf8");
+
+  assert.match(form, /name:\s*Validate a reusable Agent fix/);
+  assert.match(form, /labels:\s*\r?\n\s*- consciousness\s*\r?\n\s*- ephemeral/);
+  assert.match(
+    form,
+    /uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate/
+  );
+  assert.match(form, /id:\s*generated_validation_evidence/);
+  assert.match(form, /label:\s*Generated validation evidence/);
+  assert.match(form, /id:\s*declaration/);
+});
+
 test("extracts simplified external payload issues", () => {
   const body = [
     "## Consciousness Payload",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ This read-only command makes one cacheable request to Noosphere's public index. 
 GitHub token only when you need fresh Issue-layer results, uploads, feedback, or higher
 rate limits.
 
+## Validate Living Skill #001
+
+Run one deterministic command to reproduce a real public-artifact failure and verify its
+fix in an isolated environment:
+
+```bash
+uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
+```
+
+No repository clone, personal project, GitHub token, MCP configuration, or package-index
+account is required. The command generates reviewable evidence with exact artifact
+digests; paste the complete marked block into the
+[Skill validation form](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml).
+This is the shortest path to become an independent validator of the first community
+Living Skill.
+
 <div align="center">
   <img src="assets/demo/agent-debug-memory.gif" alt="An Agent encounters an Android node-picking failure, queries Noosphere, retrieves verified Seed Memory 35, applies the fix, and passes the regression test" width="900">
 </div>
@@ -49,8 +65,10 @@ foundational Live Skills at the explicit `maintainer-validated` trust level.
 | Founding evidence | [Issues #35](https://github.com/JinNing6/Noosphere/issues/35), [#36](https://github.com/JinNing6/Noosphere/issues/36), [#37](https://github.com/JinNing6/Noosphere/issues/37) |
 | Supply-chain protocol | [`SKILLS_PROTOCOL.md`](SKILLS_PROTOCOL.md) |
 
-**Next contribution:** independently reproduce one Founding Memory and submit the
-[structured evidence form](https://github.com/JinNing6/Noosphere/issues/new?template=consciousness-upload.yml).
+**Next contribution:** run the validation command above and submit its generated block
+through the dedicated [Skill validation form](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml).
+For a different verified engineering lesson, keep using the general
+[memory contribution form](https://github.com/JinNing6/Noosphere/issues/new?template=consciousness-upload.yml).
 **Shared it publicly? Record proof:** use the
 [Share Proof form](https://github.com/JinNing6/Noosphere/issues/new?template=share-proof.yml);
 Noosphere does not infer downloads, reposts, referrals, retention, rewards, or install counts from a URL.
@@ -65,9 +83,10 @@ and the matched historical Issue gets a backlink comment.
 | Claude Code | Repository marketplace | `/plugin marketplace add JinNing6/Noosphere` then `/plugin install noosphere@noosphere-agent-memory` |
 | Cursor / Cline / Windsurf | Standard MCP stdio server | `uvx noosphere-mcp` |
 | Terminal, read-only | Zero configuration | `uvx --from noosphere-mcp noosphere-query "your error"` |
+| Independent validation | Isolated deterministic fixture | `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate` |
 
 > [!IMPORTANT]
-> Version `v0.8.0` unifies every Skill in the live versioned registry and retains anonymous read-only consultation. Anonymous queries use
+> Version `v0.8.1` adds the first zero-setup independent validation kit while retaining the unified live registry and anonymous read-only consultation. Anonymous queries use
 > the repository's canonical public index; authenticated sessions retain the fresher Issues + permanent
 > file search path. Write operations always require GitHub authentication.
 
@@ -822,7 +841,7 @@ Unlike the old world, the Community of Consciousness continuously evolves. When 
 | `uvx` / `npx` (Recommended) | ⚡ **Auto Evolve** | Just restart the IDE / MCP client. `uvx` automatically pulls the latest version on launch |
 | `pip install` (Manual) | 🔧 Manual Upgrade | Execute `pip install --upgrade noosphere-mcp`, then restart IDE |
 
-Maintainer release path for the unified live registry: publish a semantic GitHub Release such as `v0.8.0` from the intended `main` commit. The single `release.published` trigger runs `.github/workflows/publish-pypi.yml`, which builds `noosphere-mcp` with SDK, workflow, and shared Skill supply-chain tests, then publishes through PyPI Trusted Publishing/OIDC without a stored `PYPI_TOKEN`; after the PyPI install verifier passes, it dispatches `.github/workflows/deploy-pages.yml` on `main` so GitHub Pages refreshes the public evidence and Skill indexes. Do not push the release tag separately: creating a GitHub Release also creates its tag, and two configured triggers would race to publish the same immutable PyPI version. After PyPI shows `0.8.0`, `uvx noosphere-mcp`, `uvx --from noosphere-mcp noosphere-query "your error"`, and `pip install --upgrade noosphere-mcp` deliver the 45 MCP tools, 13 live Skill registry entries, and the zero-configuration read-only query command.
+Maintainer release path for the unified live registry: publish a semantic GitHub Release such as `v0.8.1` from the intended `main` commit. The single `release.published` trigger runs `.github/workflows/publish-pypi.yml`, which builds `noosphere-mcp` with SDK, workflow, validation-kit, and shared Skill supply-chain tests, then publishes through PyPI Trusted Publishing/OIDC without a stored `PYPI_TOKEN`; after the PyPI install verifier passes, it dispatches `.github/workflows/deploy-pages.yml` on `main` so GitHub Pages refreshes the public evidence and Skill indexes. Do not push the release tag separately: creating a GitHub Release also creates its tag, and two configured triggers would race to publish the same immutable PyPI version. After PyPI shows `0.8.1`, `uvx noosphere-mcp`, `uvx --from noosphere-mcp noosphere-query "your error"`, `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate`, and `pip install --upgrade noosphere-mcp` deliver the 45 MCP tools, 13 live Skill registry entries, zero-configuration read-only query, and the deterministic independent-validation path.
 
 > 💡 **How to check**: Look at your MCP config. If `command` is `"uvx"`, you are in Auto Evolve mode; if `"python"`, you are in Manual mode.
 >

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,19 @@ uvx --from noosphere-mcp noosphere-query "React Three Fiber mobile glowing node 
 匿名只读命令只请求一次公开索引。只有查询最新 Issue、上传、反馈或提高 API
 额度时才需要 GitHub Token。
 
+## 验证第一个 Living Skill
+
+运行一条确定性命令，在隔离环境中复现真实的公共制品故障并验证修复：
+
+```bash
+uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
+```
+
+无需克隆仓库、准备个人项目、配置 GitHub Token、理解 MCP 协议或注册包索引账号。
+命令会生成包含精确制品摘要的可审查证据；将完整标记块粘贴到
+[Skill 验证表单](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml)，
+即可成为首个社区 Living Skill 的独立验证者。
+
 <div align="center">
   <img src="assets/demo/agent-debug-memory.gif" alt="Agent 遇到 Android 节点点击故障，查询 Noosphere，获得第 35 号已验证种子记忆，应用修复并通过回归测试" width="900">
 </div>
@@ -47,8 +60,9 @@ uvx --from noosphere-mcp noosphere-query "React Three Fiber mobile glowing node 
 | 首批真实证据 | [#35](https://github.com/JinNing6/Noosphere/issues/35)、[#36](https://github.com/JinNing6/Noosphere/issues/36)、[#37](https://github.com/JinNing6/Noosphere/issues/37) |
 | 供应链协议 | [`SKILLS_PROTOCOL.md`](SKILLS_PROTOCOL.md) |
 
-**下一次贡献：**独立复现一条 Founding Memory，并通过
-[结构化证据表单](https://github.com/JinNing6/Noosphere/issues/new?template=consciousness-upload.yml)提交。
+**下一次贡献：**运行上面的验证命令，并将生成结果提交到专用
+[Skill 验证表单](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml)。
+其他已验证工程经验仍可使用通用[记忆贡献表单](https://github.com/JinNing6/Noosphere/issues/new?template=consciousness-upload.yml)。
 **已经公开分享？**使用 [Share Proof 表单](https://github.com/JinNing6/Noosphere/issues/new?template=share-proof.yml)
 记录真实链接；Noosphere 不会根据 URL 虚构下载、推荐或留存数据。
 
@@ -60,9 +74,10 @@ uvx --from noosphere-mcp noosphere-query "React Three Fiber mobile glowing node 
 | Claude Code | 仓库 Marketplace | `/plugin marketplace add JinNing6/Noosphere`，然后 `/plugin install noosphere@noosphere-agent-memory` |
 | Cursor / Cline / Windsurf | 标准 MCP stdio | `uvx noosphere-mcp` |
 | 终端只读体验 | 零配置 | `uvx --from noosphere-mcp noosphere-query "你的报错"` |
+| 独立验证 | 隔离的确定性夹具 | `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate` |
 
 > [!IMPORTANT]
-> `v0.8.0` 将所有 Skill 统一到实时版本注册表，并保留匿名只读查询：匿名模式读取仓库内的规范公共索引；认证模式继续
+> `v0.8.1` 新增首个零配置独立验证夹具，同时保留统一实时注册表和匿名只读查询：匿名模式读取仓库内的规范公共索引；认证模式继续
 > 查询更新的 Issues + 永久文件。所有写操作始终要求 GitHub 身份认证。
 
 ## 记忆如何进化成 Skill

--- a/docs/live-skills.md
+++ b/docs/live-skills.md
@@ -28,6 +28,24 @@ npx skills add JinNing6/Noosphere --skill debug-async-ui
 
 MCP clients can call `list_shared_skills`, `get_shared_skill`, and `check_skill_updates`. Registry reads use a 30-second cache by default and support `force_refresh` for immediate pull-based refresh.
 
+## Validate Living Skill #001
+
+The first independent-validation sprint targets `public-artifact-runtime-smoke-gate`:
+
+```bash
+uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
+```
+
+The command builds deterministic failing and fixed Wheels, installs both through the real
+console-entry boundary in an isolated environment, and emits canonical evidence with
+artifact digests. It requires no user project, GitHub token, MCP configuration, or
+package-index account. Submit the complete generated block through the
+[dedicated validation form](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml).
+
+One submission remains a Seed-level evidence record. The existing supply-chain gate still
+requires two independent GitHub publishers with claim-level agreement and shared public
+verification before it can create a reviewable Skill Candidate.
+
 ## Catalog
 
 | Domain | Skill | Use it when |

--- a/docs/project-memory-snapshot.md
+++ b/docs/project-memory-snapshot.md
@@ -2,6 +2,16 @@
 
 Last verified: 2026-07-16 (Asia/Shanghai)
 
+## Living Skill #001 Validation Kit
+
+- Branch `codex/living-skill-validation-kit` prepares `noosphere-mcp==0.8.1` with the first zero-setup independent validation command: `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate`.
+- The validation kit requires Python 3.10+ and `uv`, but no repository clone, validator-owned project, GitHub token, MCP configuration, or package-index account. After the CLI itself is resolved, its reproduction installs only local deterministic fixture Wheels with package-index access disabled.
+- The fixture proves the source-versus-artifact boundary end to end: source invocation passes; a byte-deterministic Wheel exposes a console entry point while omitting its runtime module and fails after real installation; a fixed Wheel includes the module, reports exact installed version `1.0.1`, and passes through the same entry point.
+- Generated evidence contains environment, exit codes, immutable SHA-256 digests, the canonical shared test command, and two public source URLs inside the existing `CONSCIOUSNESS_PAYLOAD` markers. The dedicated `validate-skill.yml` form accepts this block and preserves the current author binding, moderation, canonical rehydration, independent-publisher, claim-agreement, and maintainer-review gates.
+- The general memory contribution form remains available as a secondary path. The README first screen now gives the deterministic Skill validation route the primary contribution CTA without removing existing upload or Share Proof flows.
+- Local release-candidate verification passed on Windows 11 with Python 3.12.11 and 3.13.5. A clean no-dependency install of the built `noosphere_mcp-0.8.1-py3-none-any.whl` exposed `noosphere-validate 0.8.1` and completed the full reproduction in 6.91 seconds. The fixture digests were stable at failing `66742deca82583b5e4530edba9235bc193245ff0a3b12766a53a06089ef02099` and fixed `d9aade68cae64234a5da2c848bbc868689e361bc41aebcd702baa23680963bef`.
+- Release state at this snapshot: `0.8.1` is a locally verified release candidate and is not yet claimed as published. Public usability must be reverified with the exact PyPI version after merge and Trusted Publishing.
+
 ## Living Skill Tree Frontend
 
 - Branch `codex/living-skill-tree-v1` replaces the frontend default route with an operational Living Skill Tree while preserving the complete existing 3D universe behind `?view=universe` and a persistent Universe navigation entry. Existing Issue, playground, and profile routes continue to resolve through the preserved universe application.

--- a/examples/reproductions/public-artifact-runtime-smoke-gate/README.md
+++ b/examples/reproductions/public-artifact-runtime-smoke-gate/README.md
@@ -1,0 +1,26 @@
+# Public Artifact Runtime Smoke Gate
+
+This deterministic fixture validates one release boundary: source code can run while the exact packaged artifact is broken.
+
+Run the complete reproduction and receive submission-ready evidence:
+
+```bash
+uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
+```
+
+The command requires Python 3.10+ and `uv`. It does not require a validator-owned project, GitHub token, MCP configuration, or package-index account.
+
+## What It Proves
+
+1. A source-tree module executes successfully.
+2. A deterministic failing Wheel exposes a console entry point but omits its runtime module.
+3. The Wheel is installed into a clean virtual environment with network package resolution disabled.
+4. The real installed entry point fails with the expected missing-module error.
+5. A deterministic fixed Wheel is force-installed into the same isolated environment.
+6. The real entry point succeeds and the installed distribution reports the exact fixed version.
+
+The generated Markdown contains artifact SHA-256 digests, environment details, observed exit codes, the canonical test command, and public sources. Paste the complete marked block into the [Skill validation form](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml).
+
+Submission does not publish a Skill directly. Existing repository automation binds authorship to the GitHub Issue author, moderates the structured evidence, compares independent claims, and creates a review-gated Candidate only after the supply-chain requirements are met.
+
+See [`contract.json`](./contract.json) for the machine-readable fixture contract.

--- a/examples/reproductions/public-artifact-runtime-smoke-gate/contract.json
+++ b/examples/reproductions/public-artifact-runtime-smoke-gate/contract.json
@@ -1,0 +1,10 @@
+{
+  "skill": "public-artifact-runtime-smoke-gate",
+  "distribution": "noosphere-public-artifact-fixture",
+  "entry_point": "noosphere-runtime-fixture",
+  "failing_version": "1.0.0",
+  "fixed_version": "1.0.1",
+  "expected_failure": "installed console entry point cannot import noosphere_public_artifact_fixture.__main__",
+  "expected_success": "installed console entry point reports runtime-ok and version 1.0.1",
+  "validation_command": "uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate"
+}

--- a/scripts/test_verify_pypi_release.py
+++ b/scripts/test_verify_pypi_release.py
@@ -57,12 +57,28 @@ class VerifyPypiReleaseTests(unittest.TestCase):
             tool_names = [f"tool_{index}" for index in range(35)] + REQUIRED_GROWTH_TOOLS
             (package_root / "noosphere_mcp.py").write_text(_tool_source(tool_names), encoding="utf-8")
             (package_root / "query_cli.py").write_text("def main(): return 0\n", encoding="utf-8")
+            (package_root / "validation_cli.py").write_text("def main(): return 0\n", encoding="utf-8")
+            validation_kits = package_root / "validation_kits"
+            validation_kits.mkdir()
+            (validation_kits / "public_artifact_runtime_smoke_gate.py").write_text(
+                "def run_validation(): return True\n", encoding="utf-8"
+            )
+            dist_info = target / "noosphere_mcp-0.6.8.dist-info"
+            dist_info.mkdir()
+            (dist_info / "entry_points.txt").write_text(
+                "[console_scripts]\n"
+                "noosphere-mcp = noosphere.server:main\n"
+                "noosphere-query = noosphere.query_cli:main\n"
+                "noosphere-validate = noosphere.validation_cli:main\n",
+                encoding="utf-8",
+            )
 
             result = inspect_installed_release(target, "0.6.8", expected_tool_count=40)
 
         self.assertEqual(result["version"], "0.6.8")
         self.assertEqual(result["tool_count"], 40)
         self.assertEqual(result["query_cli"], "noosphere-query")
+        self.assertEqual(result["validation_cli"], "noosphere-validate")
 
     def test_install_release_to_target_uses_exact_version_and_no_deps(self):
         with patch("scripts.verify_pypi_release.subprocess.run") as run:

--- a/scripts/verify_pypi_release.py
+++ b/scripts/verify_pypi_release.py
@@ -144,14 +144,26 @@ def inspect_installed_release(
     init_path = package_root / "__init__.py"
     mcp_path = package_root / "noosphere_mcp.py"
     query_cli_path = package_root / "query_cli.py"
-    if not init_path.exists() or not mcp_path.exists() or not query_cli_path.exists():
+    validation_cli_path = package_root / "validation_cli.py"
+    validation_kit_path = package_root / "validation_kits" / "public_artifact_runtime_smoke_gate.py"
+    entry_points_path = target_dir / f"noosphere_mcp-{expected_version}.dist-info" / "entry_points.txt"
+    required_paths = [
+        init_path,
+        mcp_path,
+        query_cli_path,
+        validation_cli_path,
+        validation_kit_path,
+        entry_points_path,
+    ]
+    missing_paths = [path.relative_to(target_dir).as_posix() for path in required_paths if not path.exists()]
+    if missing_paths:
         raise RuntimeError(
-            f"Installed package is missing {package_dir}/__init__.py, "
-            f"{package_dir}/noosphere_mcp.py, or {package_dir}/query_cli.py"
+            "Installed package is missing required release files: " + ", ".join(missing_paths)
         )
 
     init_source = init_path.read_text(encoding="utf-8")
     mcp_source = mcp_path.read_text(encoding="utf-8")
+    entry_points = entry_points_path.read_text(encoding="utf-8")
 
     version_match = re.search(r'__version__\s*=\s*"([^"]+)"', init_source)
     installed_version = version_match.group(1) if version_match else ""
@@ -169,11 +181,25 @@ def inspect_installed_release(
     if missing_tools:
         raise RuntimeError(f"Installed package is missing growth tool(s): {', '.join(missing_tools)}")
 
+    required_entry_points = {
+        "noosphere-mcp = noosphere.server:main",
+        "noosphere-query = noosphere.query_cli:main",
+        "noosphere-validate = noosphere.validation_cli:main",
+    }
+    missing_entry_points = sorted(
+        entry_point for entry_point in required_entry_points if entry_point not in entry_points
+    )
+    if missing_entry_points:
+        raise RuntimeError(
+            "Installed package is missing console entry point(s): " + ", ".join(missing_entry_points)
+        )
+
     return {
         "version": installed_version,
         "tool_count": len(tool_names),
         "growth_tools": REQUIRED_GROWTH_TOOLS,
         "query_cli": "noosphere-query",
+        "validation_cli": "noosphere-validate",
     }
 
 
@@ -214,7 +240,8 @@ def main(argv: list[str] | None = None) -> int:
     result = verify_pypi_release(args.project, args.version, args.attempts, args.delay_seconds, args.tool_count)
     print(
         f"Verified {result['project']}=={result['version']}: "
-        f"{result['tool_count']} MCP tools, growth ledger tools and noosphere-query present."
+        f"{result['tool_count']} MCP tools, growth ledger tools, noosphere-query and "
+        "noosphere-validate present."
     )
     return 0
 

--- a/sdk/noosphere/__init__.py
+++ b/sdk/noosphere/__init__.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
     from noosphere.client import Noosphere
 
 __all__ = ["Noosphere"]
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 
 def __getattr__(name: str):

--- a/sdk/noosphere/validation_cli.py
+++ b/sdk/noosphere/validation_cli.py
@@ -1,0 +1,102 @@
+"""Low-friction, deterministic Noosphere Skill validation command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import webbrowser
+from pathlib import Path
+
+from noosphere import __version__
+from noosphere.validation_kits.public_artifact_runtime_smoke_gate import (
+    FORM_URL,
+    SKILL_NAME,
+    ValidationKitError,
+    render_evidence_markdown,
+    run_validation,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="noosphere-validate",
+        description="Independently reproduce a Noosphere Skill with a deterministic fixture.",
+    )
+    parser.add_argument("skill", choices=[SKILL_NAME], help="The Skill validation kit to run")
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Evidence output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path for the generated evidence; stdout is used by default",
+    )
+    parser.add_argument(
+        "--keep-workdir",
+        action="store_true",
+        help="Keep generated wheels and the isolated environment for local inspection",
+    )
+    parser.add_argument(
+        "--open-form",
+        action="store_true",
+        help="Open the GitHub validation form after a successful run",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    return parser
+
+
+def configure_console_output() -> None:
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if callable(reconfigure):
+        reconfigure(encoding=sys.stdout.encoding or "utf-8", errors="replace")
+
+
+def _render_json(result, workdir: Path | None) -> str:
+    data = json.loads(result.as_json())
+    data["workdir"] = str(workdir) if workdir else None
+    data["submission_url"] = FORM_URL
+    return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    configure_console_output()
+    retained_workdir: Path | None = None
+
+    try:
+        if args.keep_workdir:
+            retained_workdir = Path(tempfile.mkdtemp(prefix="noosphere-validation-"))
+            result = run_validation(retained_workdir)
+        else:
+            with tempfile.TemporaryDirectory(prefix="noosphere-validation-") as temporary:
+                result = run_validation(Path(temporary))
+
+        output = (
+            render_evidence_markdown(result) if args.format == "markdown" else _render_json(result, retained_workdir)
+        )
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(f"{output}\n", encoding="utf-8")
+            print(f"Validation evidence written to {args.output}")
+        else:
+            print(output)
+        if retained_workdir:
+            print(f"Validation workdir retained at {retained_workdir}")
+        if result.passed and args.open_form:
+            webbrowser.open(FORM_URL, new=2)
+        return 0 if result.passed else 1
+    except (OSError, subprocess.SubprocessError, ValidationKitError) as exc:
+        print(f"Validation harness failed: {exc}", file=sys.stderr)
+        if retained_workdir:
+            print(f"Validation workdir retained at {retained_workdir}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/noosphere/validation_kits/__init__.py
+++ b/sdk/noosphere/validation_kits/__init__.py
@@ -1,0 +1,19 @@
+"""Deterministic validation kits for independently reproducing Agent Skills."""
+
+from .public_artifact_runtime_smoke_gate import (
+    FORM_URL,
+    SKILL_NAME,
+    ValidationKitError,
+    ValidationResult,
+    render_evidence_markdown,
+    run_validation,
+)
+
+__all__ = [
+    "FORM_URL",
+    "SKILL_NAME",
+    "ValidationKitError",
+    "ValidationResult",
+    "render_evidence_markdown",
+    "run_validation",
+]

--- a/sdk/noosphere/validation_kits/public_artifact_runtime_smoke_gate.py
+++ b/sdk/noosphere/validation_kits/public_artifact_runtime_smoke_gate.py
@@ -1,0 +1,389 @@
+"""Reproduce source-versus-public-artifact runtime drift without a user project."""
+
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import io
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+import venv
+import zipfile
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+SKILL_NAME = "public-artifact-runtime-smoke-gate"
+VALIDATION_COMMAND = "uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate"
+FORM_URL = "https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml"
+FIXTURE_URL = (
+    "https://github.com/JinNing6/Noosphere/tree/main/examples/reproductions/public-artifact-runtime-smoke-gate"
+)
+SEED_URL = "https://github.com/JinNing6/Noosphere/issues/37"
+
+DIST_NAME = "noosphere-public-artifact-fixture"
+PACKAGE_NAME = "noosphere_public_artifact_fixture"
+ENTRY_POINT = "noosphere-runtime-fixture"
+FAILING_VERSION = "1.0.0"
+FIXED_VERSION = "1.0.1"
+
+PAYLOAD_START = "<!-- CONSCIOUSNESS_PAYLOAD_START -->"
+PAYLOAD_END = "<!-- CONSCIOUSNESS_PAYLOAD_END -->"
+
+
+class ValidationKitError(RuntimeError):
+    """Raised when the validation harness itself cannot complete."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def combined_output(self) -> str:
+        return "\n".join(part for part in [self.stdout.strip(), self.stderr.strip()] if part).strip()
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    skill_name: str
+    passed: bool
+    duration_seconds: float
+    environment: str
+    source_exit_code: int
+    failing_artifact_exit_code: int
+    fixed_artifact_exit_code: int
+    failing_artifact_sha256: str
+    fixed_artifact_sha256: str
+    installed_fixed_version: str
+    observed_failure: str
+    observed_success: str
+    workdir: str | None = None
+
+    def as_json(self) -> str:
+        return json.dumps(asdict(self), ensure_ascii=False, indent=2)
+
+
+def _runtime_module(version: str) -> bytes:
+    source = f'''"""Runtime entry point for the Noosphere public-artifact fixture."""
+
+import json
+
+from . import __version__
+
+
+def main() -> int:
+    print(json.dumps({{
+        "distribution": "{DIST_NAME}",
+        "status": "runtime-ok",
+        "version": __version__,
+    }}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+    return source.encode("utf-8")
+
+
+def _package_init(version: str) -> bytes:
+    return f'__version__ = "{version}"\n'.encode()
+
+
+def _record_line(path: str, content: bytes) -> list[str]:
+    digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode("ascii")
+    return [path, f"sha256={digest}", str(len(content))]
+
+
+def _record_bytes(files: dict[str, bytes], record_path: str) -> bytes:
+    output = io.StringIO(newline="")
+    writer = csv.writer(output, lineterminator="\n")
+    for path in sorted(files):
+        writer.writerow(_record_line(path, files[path]))
+    writer.writerow([record_path, "", ""])
+    return output.getvalue().encode("utf-8")
+
+
+def build_fixture_wheel(destination: Path, version: str, *, include_runtime_module: bool) -> Path:
+    """Build a deterministic pure-Python wheel using only the standard library."""
+    destination.mkdir(parents=True, exist_ok=True)
+    normalized_dist = DIST_NAME.replace("-", "_")
+    dist_info = f"{normalized_dist}-{version}.dist-info"
+    wheel_name = f"{normalized_dist}-{version}-py3-none-any.whl"
+    wheel_path = destination / wheel_name
+
+    files: dict[str, bytes] = {
+        f"{PACKAGE_NAME}/__init__.py": _package_init(version),
+        f"{dist_info}/METADATA": (
+            "Metadata-Version: 2.1\n"
+            f"Name: {DIST_NAME}\n"
+            f"Version: {version}\n"
+            "Summary: Deterministic Noosphere validation fixture\n"
+        ).encode(),
+        f"{dist_info}/WHEEL": (
+            b"Wheel-Version: 1.0\nGenerator: noosphere-validate\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        ),
+        f"{dist_info}/entry_points.txt": (
+            f"[console_scripts]\n{ENTRY_POINT} = {PACKAGE_NAME}.__main__:main\n"
+        ).encode(),
+        f"{dist_info}/top_level.txt": f"{PACKAGE_NAME}\n".encode(),
+    }
+    if include_runtime_module:
+        files[f"{PACKAGE_NAME}/__main__.py"] = _runtime_module(version)
+
+    record_path = f"{dist_info}/RECORD"
+    files[record_path] = _record_bytes(files, record_path)
+
+    # Stored entries keep the fixture byte-identical across zlib implementations.
+    with zipfile.ZipFile(wheel_path, "w", compression=zipfile.ZIP_STORED) as archive:
+        for name in sorted(files):
+            info = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_STORED
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, files[name])
+    return wheel_path
+
+
+def _clean_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for key in ["PYTHONHOME", "PYTHONPATH", "GITHUB_TOKEN", "GH_TOKEN"]:
+        environment.pop(key, None)
+    environment["PYTHONNOUSERSITE"] = "1"
+    environment["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    return environment
+
+
+def _run(command: Sequence[str | os.PathLike[str]], *, cwd: Path, timeout: int = 90) -> CommandResult:
+    completed = subprocess.run(
+        [os.fspath(item) for item in command],
+        cwd=cwd,
+        env=_clean_environment(),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+        check=False,
+    )
+    return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def _require_success(result: CommandResult, operation: str) -> None:
+    if result.returncode != 0:
+        detail = result.combined_output[-2000:] or "no output"
+        raise ValidationKitError(f"{operation} failed with exit code {result.returncode}: {detail}")
+
+
+def _venv_python(environment: Path) -> Path:
+    return environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _venv_entry_point(environment: Path) -> Path:
+    suffix = ".exe" if os.name == "nt" else ""
+    return environment / ("Scripts" if os.name == "nt" else "bin") / f"{ENTRY_POINT}{suffix}"
+
+
+def _safe_output(value: str, workdir: Path, *, max_length: int = 1600) -> str:
+    normalized = value.replace(str(workdir), "<validation-workdir>")
+    normalized = normalized.replace(str(workdir).replace("\\", "/"), "<validation-workdir>")
+    return normalized.strip()[-max_length:]
+
+
+def _environment_summary() -> str:
+    return " / ".join(
+        [
+            platform.system() or "unknown-os",
+            platform.release() or "unknown-release",
+            platform.machine() or "unknown-architecture",
+            f"Python {platform.python_version()}",
+        ]
+    )
+
+
+def run_validation(workdir: Path) -> ValidationResult:
+    """Run the complete source, failing-artifact, and fixed-artifact lifecycle."""
+    started = time.monotonic()
+    workdir = workdir.resolve()
+    source_root = workdir / "source"
+    package_root = source_root / PACKAGE_NAME
+    wheelhouse = workdir / "wheelhouse"
+    runtime_root = workdir / "runtime"
+    environment = workdir / "isolated-environment"
+    package_root.mkdir(parents=True, exist_ok=True)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    (package_root / "__init__.py").write_bytes(_package_init(FIXED_VERSION))
+    (package_root / "__main__.py").write_bytes(_runtime_module(FIXED_VERSION))
+
+    source_result = _run([sys.executable, "-m", PACKAGE_NAME], cwd=source_root)
+    if source_result.returncode != 0 or '"status": "runtime-ok"' not in source_result.stdout:
+        raise ValidationKitError(
+            "The fixture source tree did not pass before artifact packaging: "
+            f"{_safe_output(source_result.combined_output, workdir)}"
+        )
+
+    failing_wheel = build_fixture_wheel(wheelhouse, FAILING_VERSION, include_runtime_module=False)
+    fixed_wheel = build_fixture_wheel(wheelhouse, FIXED_VERSION, include_runtime_module=True)
+    failing_sha = hashlib.sha256(failing_wheel.read_bytes()).hexdigest()
+    fixed_sha = hashlib.sha256(fixed_wheel.read_bytes()).hexdigest()
+
+    venv.EnvBuilder(with_pip=True, clear=True).create(environment)
+    python = _venv_python(environment)
+    install_failing = _run(
+        [python, "-m", "pip", "install", "--no-index", "--no-deps", failing_wheel],
+        cwd=runtime_root,
+    )
+    _require_success(install_failing, "Installing the failing fixture wheel")
+
+    entry_point = _venv_entry_point(environment)
+    if not entry_point.is_file():
+        raise ValidationKitError(f"Installed console entry point was not created: {entry_point}")
+    failing_result = _run([entry_point], cwd=runtime_root)
+
+    install_fixed = _run(
+        [
+            python,
+            "-m",
+            "pip",
+            "install",
+            "--no-index",
+            "--no-deps",
+            "--force-reinstall",
+            fixed_wheel,
+        ],
+        cwd=runtime_root,
+    )
+    _require_success(install_fixed, "Installing the fixed fixture wheel")
+    fixed_result = _run([entry_point], cwd=runtime_root)
+    version_result = _run(
+        [
+            python,
+            "-I",
+            "-c",
+            (f"import importlib.metadata as m; print(m.version('{DIST_NAME}'))"),
+        ],
+        cwd=runtime_root,
+    )
+
+    observed_failure = _safe_output(failing_result.combined_output, workdir)
+    observed_success = _safe_output(fixed_result.combined_output, workdir)
+    installed_version = version_result.stdout.strip()
+    passed = all(
+        [
+            source_result.returncode == 0,
+            failing_result.returncode != 0,
+            "no module named" in observed_failure.lower(),
+            f"{PACKAGE_NAME}.__main__" in observed_failure,
+            fixed_result.returncode == 0,
+            '"status": "runtime-ok"' in observed_success,
+            version_result.returncode == 0,
+            installed_version == FIXED_VERSION,
+        ]
+    )
+
+    return ValidationResult(
+        skill_name=SKILL_NAME,
+        passed=passed,
+        duration_seconds=round(time.monotonic() - started, 2),
+        environment=_environment_summary(),
+        source_exit_code=source_result.returncode,
+        failing_artifact_exit_code=failing_result.returncode,
+        fixed_artifact_exit_code=fixed_result.returncode,
+        failing_artifact_sha256=failing_sha,
+        fixed_artifact_sha256=fixed_sha,
+        installed_fixed_version=installed_version,
+        observed_failure=observed_failure,
+        observed_success=observed_success,
+        workdir=None,
+    )
+
+
+def build_evidence_payload(result: ValidationResult) -> dict:
+    if not result.passed:
+        raise ValidationKitError("A failed harness run cannot be submitted as verified evidence")
+    verification = (
+        f"Source invocation exited {result.source_exit_code}; the installed failing artifact exited "
+        f"{result.failing_artifact_exit_code}; the fixed artifact exited "
+        f"{result.fixed_artifact_exit_code} and reported version {result.installed_fixed_version}. "
+        f"Failing SHA-256: {result.failing_artifact_sha256}. "
+        f"Fixed SHA-256: {result.fixed_artifact_sha256}."
+    )
+    return {
+        "creator_signature": "independent-validator",
+        "is_anonymous": False,
+        "consciousness_type": "pattern",
+        "target_skill": SKILL_NAME,
+        "thought_vector_text": (
+            "Source-tree tests can pass while the installed release omits a runtime module. "
+            "Validate the exact artifact in a clean environment before declaring a CLI, package, "
+            "MCP server, or Agent plugin releasable."
+        ),
+        "context_environment": (
+            f"Independent deterministic fixture executed on {result.environment}. "
+            "No validator-owned project, GitHub token, or external package index was used."
+        ),
+        "tags": ["build-release", "artifact-runtime", "python-packaging", "mcp"],
+        "evidence": {
+            "symptom": (
+                "The source-tree entry point succeeds, but the console entry point installed from "
+                "the failing wheel exits non-zero because its runtime module is absent."
+            ),
+            "root_cause": (
+                "Release checks exercised the source tree instead of the exact built artifact. "
+                "The wheel metadata exposed a console entry point while packaging omitted the module "
+                "that implements it."
+            ),
+            "fix": (
+                "Install the exact artifact in a clean environment, verify the installed distribution "
+                "version, invoke its real console entry point, and assert the runtime contract. Include "
+                "the entry-point module in the immutable artifact."
+            ),
+            "verification": verification,
+            "applies_when": (
+                "A Python package, CLI, MCP server, or Agent plugin passes source CI but may differ "
+                "after wheel or public-registry installation."
+            ),
+            "avoid_when": (
+                "Do not attribute failures to packaging when the exact artifact was never resolved, "
+                "or when the distribution intentionally exposes no runtime entry point."
+            ),
+            "test_commands": [VALIDATION_COMMAND],
+            "source_urls": [FIXTURE_URL, SEED_URL],
+        },
+    }
+
+
+def render_evidence_markdown(result: ValidationResult) -> str:
+    payload = build_evidence_payload(result)
+    return "\n".join(
+        [
+            "# Noosphere Skill validation",
+            "",
+            "- Result: **PASS**",
+            f"- Skill: `{SKILL_NAME}`",
+            f"- Environment: `{result.environment}`",
+            f"- Duration: `{result.duration_seconds:.2f}s`",
+            f"- Failing artifact: `{result.failing_artifact_sha256}`",
+            f"- Fixed artifact: `{result.fixed_artifact_sha256}`",
+            "",
+            "Paste the complete block below into the **Generated validation evidence** field:",
+            "",
+            PAYLOAD_START,
+            "```json",
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            "```",
+            PAYLOAD_END,
+            "",
+            f"Submit: {FORM_URL}",
+            "",
+            "The repository workflow binds authorship to the submitting GitHub account and "
+            "review-gates the evidence before it can affect a published Skill.",
+        ]
+    )

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "noosphere-mcp"
-version = "0.8.0"
+version = "0.8.1"
 description = "🧠 Noosphere — 集体意识网络 MCP Server，直连 GitHub 意识仓库"
 readme = "../README.md"
 requires-python = ">=3.10"
@@ -51,6 +51,7 @@ Issues = "https://github.com/JinNing6/Noosphere/issues"
 [project.scripts]
 noosphere-mcp = "noosphere.server:main"
 noosphere-query = "noosphere.query_cli:main"
+noosphere-validate = "noosphere.validation_cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["noosphere"]

--- a/sdk/server.json
+++ b/sdk/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "JinNing6/Noosphere"
   },
-  "version": "0.8.0",
+  "version": "0.8.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "noosphere-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/sdk/tests/test_release_boundary.py
+++ b/sdk/tests/test_release_boundary.py
@@ -49,6 +49,14 @@ def test_release_exposes_zero_configuration_read_only_query_command():
     assert (SDK_ROOT / "noosphere" / "query_cli.py").is_file()
 
 
+def test_release_exposes_deterministic_living_skill_validation_command():
+    scripts = _project_metadata()["project"]["scripts"]
+
+    assert scripts["noosphere-validate"] == "noosphere.validation_cli:main"
+    assert (SDK_ROOT / "noosphere" / "validation_cli.py").is_file()
+    assert (SDK_ROOT / "noosphere" / "validation_kits" / "public_artifact_runtime_smoke_gate.py").is_file()
+
+
 def test_publish_workflow_uses_single_release_trigger_with_trusted_publishing_quality_gates():
     workflow = (REPO_ROOT / ".github" / "workflows" / "publish-pypi.yml").read_text(encoding="utf-8")
 
@@ -112,3 +120,4 @@ def test_readme_documents_pypi_release_recovery_route():
     assert ".github/workflows/publish-pypi.yml" in readme
     assert "Trusted Publishing" in readme
     assert "45 MCP tools" in readme
+    assert "noosphere-validate public-artifact-runtime-smoke-gate" in readme

--- a/sdk/tests/test_validation_cli.py
+++ b/sdk/tests/test_validation_cli.py
@@ -1,0 +1,83 @@
+import hashlib
+import json
+import zipfile
+from unittest.mock import patch
+
+import pytest
+
+from noosphere.validation_cli import build_parser, main
+from noosphere.validation_kits.public_artifact_runtime_smoke_gate import (
+    FIXED_VERSION,
+    FORM_URL,
+    PACKAGE_NAME,
+    PAYLOAD_END,
+    PAYLOAD_START,
+    SKILL_NAME,
+    VALIDATION_COMMAND,
+    build_evidence_payload,
+    build_fixture_wheel,
+    render_evidence_markdown,
+    run_validation,
+)
+
+
+@pytest.fixture(scope="module")
+def completed_validation(tmp_path_factory):
+    return run_validation(tmp_path_factory.mktemp("public-artifact-validation"))
+
+
+def test_fixture_wheels_are_byte_deterministic_and_expose_the_same_entry_point(tmp_path):
+    first = build_fixture_wheel(tmp_path / "first", "1.0.1", include_runtime_module=True)
+    second = build_fixture_wheel(tmp_path / "second", "1.0.1", include_runtime_module=True)
+
+    assert first.read_bytes() == second.read_bytes()
+    assert hashlib.sha256(first.read_bytes()).hexdigest() == hashlib.sha256(second.read_bytes()).hexdigest()
+
+    with zipfile.ZipFile(first) as archive:
+        names = set(archive.namelist())
+        entry_points = archive.read("noosphere_public_artifact_fixture-1.0.1.dist-info/entry_points.txt").decode(
+            "utf-8"
+        )
+
+    assert f"{PACKAGE_NAME}/__main__.py" in names
+    assert "noosphere-runtime-fixture = noosphere_public_artifact_fixture.__main__:main" in entry_points
+
+
+def test_validation_reproduces_the_artifact_failure_and_verifies_the_fix(completed_validation):
+    result = completed_validation
+
+    assert result.passed is True
+    assert result.source_exit_code == 0
+    assert result.failing_artifact_exit_code != 0
+    assert result.fixed_artifact_exit_code == 0
+    assert result.installed_fixed_version == FIXED_VERSION
+    assert "no module named" in result.observed_failure.lower()
+    assert f"{PACKAGE_NAME}.__main__" in result.observed_failure
+    assert '"status": "runtime-ok"' in result.observed_success
+    assert "<validation-workdir>" in result.observed_failure
+
+
+def test_generated_evidence_is_canonical_and_submission_ready(completed_validation):
+    payload = build_evidence_payload(completed_validation)
+    markdown = render_evidence_markdown(completed_validation)
+    marker_body = markdown.split(PAYLOAD_START, 1)[1].split(PAYLOAD_END, 1)[0].strip()
+    parsed = json.loads(marker_body.removeprefix("```json").removesuffix("```").strip())
+
+    assert parsed == payload
+    assert payload["target_skill"] == SKILL_NAME
+    assert payload["evidence"]["test_commands"] == [VALIDATION_COMMAND]
+    assert len(payload["evidence"]["source_urls"]) == 2
+    assert all(url.startswith("https://github.com/") for url in payload["evidence"]["source_urls"])
+    assert FORM_URL in markdown
+
+
+def test_cli_has_one_explicit_kit_and_writes_generated_evidence(tmp_path, completed_validation):
+    args = build_parser().parse_args([SKILL_NAME, "--format", "markdown"])
+    output = tmp_path / "evidence.md"
+
+    assert args.skill == SKILL_NAME
+    with patch("noosphere.validation_cli.run_validation", return_value=completed_validation):
+        exit_code = main([SKILL_NAME, "--output", str(output)])
+
+    assert exit_code == 0
+    assert PAYLOAD_START in output.read_text(encoding="utf-8")

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "JinNing6/Noosphere"
   },
-  "version": "0.8.0",
+  "version": "0.8.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "noosphere-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- add `noosphere-validate public-artifact-runtime-smoke-gate`, a deterministic zero-setup validation kit that reproduces source-versus-artifact drift through real installed console entry points
- add a dedicated GitHub Issue Form whose generated payload continues through the existing author-binding, moderation, independent-publisher, candidate, and maintainer-review gates
- publish the validation path on the English and Chinese README first screens and prepare SDK release `0.8.1`
- strengthen the PyPI verifier so the new module, fixture, and console entry point are release blockers

## Verified behavior
- source fixture exits 0
- intentionally broken Wheel installs but its real console entry exits 1 with the expected missing runtime module
- fixed Wheel reports installed version 1.0.1 and exits 0 through the same entry point
- byte-identical fixture Wheels produce stable SHA-256 digests across repeated builds
- clean no-dependency install of the built `noosphere_mcp-0.8.1` Wheel exposes and runs `noosphere-validate 0.8.1`

## Quality gates
- `python -m pytest sdk/tests -q` -> 203 passed
- `node --test .github/scripts/*.test.cjs` -> 93 passed
- repository release/supply-chain tests -> 20 passed
- shared Skill registry and promotion migration checks passed
- Issue Form YAML schema sanity check passed
- focused Ruff and `git diff --check` passed