### PR TITLE
Fix Glama MCP cold-start discovery

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Verify published PyPI package
+      - name: Verify published PyPI package with initialize + tools/list
         run: python scripts/verify_pypi_release.py --tool-count 45
 
   refresh-pages-proof:

--- a/README.md
+++ b/README.md
@@ -85,10 +85,19 @@ and the matched historical Issue gets a backlink comment.
 | Terminal, read-only | Zero configuration | `uvx --from noosphere-mcp noosphere-query "your error"` |
 | Independent validation | Isolated deterministic fixture | `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate` |
 
+The default MCP install is intentionally lightweight and uses BM25 when local semantic
+dependencies are absent. Enable the optional multilingual embedding model only when you
+need local hybrid semantic ranking:
+
+```bash
+uvx --from 'noosphere-mcp[semantic]' noosphere-mcp
+```
+
 > [!IMPORTANT]
-> Version `v0.8.1` adds the first zero-setup independent validation kit while retaining the unified live registry and anonymous read-only consultation. Anonymous queries use
+> Version `v0.8.2` keeps the default MCP runtime scanner-friendly by making the local semantic model optional, pins the stable MCP SDK 1.x boundary, and verifies every public release with a real anonymous `initialize + tools/list` handshake. It retains the zero-setup validation kit, unified live registry, and anonymous read-only consultation. Anonymous queries use
 > the repository's canonical public index; authenticated sessions retain the fresher Issues + permanent
-> file search path. Write operations always require GitHub authentication.
+> file search path. Install the `semantic` extra for local multilingual vector ranking;
+> otherwise search degrades to BM25. Write operations always require GitHub authentication.
 
 ## How memory becomes a Skill
 
@@ -841,7 +850,7 @@ Unlike the old world, the Community of Consciousness continuously evolves. When 
 | `uvx` / `npx` (Recommended) | ⚡ **Auto Evolve** | Just restart the IDE / MCP client. `uvx` automatically pulls the latest version on launch |
 | `pip install` (Manual) | 🔧 Manual Upgrade | Execute `pip install --upgrade noosphere-mcp`, then restart IDE |
 
-Maintainer release path for the unified live registry: publish a semantic GitHub Release such as `v0.8.1` from the intended `main` commit. The single `release.published` trigger runs `.github/workflows/publish-pypi.yml`, which builds `noosphere-mcp` with SDK, workflow, validation-kit, and shared Skill supply-chain tests, then publishes through PyPI Trusted Publishing/OIDC without a stored `PYPI_TOKEN`; after the PyPI install verifier passes, it dispatches `.github/workflows/deploy-pages.yml` on `main` so GitHub Pages refreshes the public evidence and Skill indexes. Do not push the release tag separately: creating a GitHub Release also creates its tag, and two configured triggers would race to publish the same immutable PyPI version. After PyPI shows `0.8.1`, `uvx noosphere-mcp`, `uvx --from noosphere-mcp noosphere-query "your error"`, `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate`, and `pip install --upgrade noosphere-mcp` deliver the 45 MCP tools, 13 live Skill registry entries, zero-configuration read-only query, and the deterministic independent-validation path.
+Maintainer release path for the unified live registry: publish a semantic GitHub Release such as `v0.8.2` from the intended `main` commit. The single `release.published` trigger runs `.github/workflows/publish-pypi.yml`, which builds `noosphere-mcp` with SDK, workflow, validation-kit, and shared Skill supply-chain tests, then publishes through PyPI Trusted Publishing/OIDC without a stored `PYPI_TOKEN`; after the PyPI verifier performs a real anonymous `initialize + tools/list` handshake against a clean installed runtime, it dispatches `.github/workflows/deploy-pages.yml` on `main` so GitHub Pages refreshes the public evidence and Skill indexes. Do not push the release tag separately: creating a GitHub Release also creates its tag, and two configured triggers would race to publish the same immutable PyPI version. After PyPI shows `0.8.2`, `uvx noosphere-mcp`, `uvx --from noosphere-mcp noosphere-query "your error"`, `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate`, and `pip install --upgrade noosphere-mcp` deliver the 45 MCP tools, 13 live Skill registry entries, zero-configuration read-only query, and the deterministic independent-validation path.
 
 > 💡 **How to check**: Look at your MCP config. If `command` is `"uvx"`, you are in Auto Evolve mode; if `"python"`, you are in Manual mode.
 >

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,9 +76,16 @@ uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
 | 终端只读体验 | 零配置 | `uvx --from noosphere-mcp noosphere-query "你的报错"` |
 | 独立验证 | 隔离的确定性夹具 | `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate` |
 
+默认 MCP 安装刻意保持轻量；未安装本地语义依赖时自动使用 BM25。只有需要本地多语言
+混合语义排序时，才显式启用可选模型：
+
+```bash
+uvx --from 'noosphere-mcp[semantic]' noosphere-mcp
+```
+
 > [!IMPORTANT]
-> `v0.8.1` 新增首个零配置独立验证夹具，同时保留统一实时注册表和匿名只读查询：匿名模式读取仓库内的规范公共索引；认证模式继续
-> 查询更新的 Issues + 永久文件。所有写操作始终要求 GitHub 身份认证。
+> `v0.8.2` 将本地语义模型改为可选依赖，固定稳定的 MCP SDK 1.x 边界，并要求每次公开发布都在干净安装环境完成真实匿名 `initialize + tools/list` 握手，因此默认运行时可被 Glama 等目录快速扫描。首个零配置独立验证夹具、统一实时注册表和匿名只读查询均保留：匿名模式读取仓库内的规范公共索引；认证模式继续
+> 查询更新的 Issues + 永久文件。需要本地多语言向量排序时安装 `semantic` extra，否则自动降级为 BM25。所有写操作始终要求 GitHub 身份认证。
 
 ## 记忆如何进化成 Skill
 

--- a/docs/project-memory-snapshot.md
+++ b/docs/project-memory-snapshot.md
@@ -2,6 +2,15 @@
 
 Last verified: 2026-07-16 (Asia/Shanghai)
 
+## Glama MCP Directory Recovery
+
+- Glama's public server record was stale and unhealthy at diagnosis time: its API returned `tools: []`, treated `GITHUB_TOKEN` and `NOOSPHERE_REPO` as required, and the rendered schema still exposed only three legacy tools. The repository `glama.json` remains valid against Glama's current schema, so metadata syntax was not the failure.
+- The failure was reproduced at the public-artifact boundary. A fresh `noosphere-mcp==0.8.1` environment installed 64 packages including Torch, Transformers, SciPy, NumPy, and Sentence Transformers; cold import took 72.67 seconds and a complete MCP handshake still had not returned after 244 seconds. Reusing the installed environment completed `initialize + tools/list` in 0.81 seconds and returned all 45 tools, proving the server contract was healthy but the directory scanner's cold-start budget was exceeded.
+- Release candidate `0.8.2` moves the local Sentence Transformers stack behind the `semantic` extra and keeps the default install on `mcp>=1.27,<2` plus `httpx`. Precomputed cross-modal vector search remains available without NumPy through an exact standard-library cosine fallback; installing the extra retains NumPy acceleration and local multilingual embedding generation.
+- FastMCP 1.x is explicitly bound to the Noosphere package version so `initialize.serverInfo.version` no longer reports the MCP SDK version. The PyPI post-publish verifier now creates a second clean environment, installs the exact public artifact with dependencies, removes optional GitHub credentials, and requires a real `initialize + tools/list` response with the exact release version and 45 tools within 30 seconds.
+- Local candidate verification passed: 206 SDK tests, 25 repository script tests, 93 Node supply-chain tests, and focused plus critical Ruff checks. A newly built `0.8.2` Wheel installed 34 lightweight distributions with none of `torch`, `transformers`, `sentence-transformers`, `scipy`, or `numpy`; its anonymous MCP handshake returned 45 tools in 0.86 seconds and reported version `0.8.2`.
+- Remaining external steps are merge, GitHub Release/PyPI publication of `0.8.2`, successful execution of the strengthened public-artifact verifier, then Glama admin `Sync Server` or the next daily sync. Completion requires the public Glama API to expose 45 tools, optional authentication, and current metadata rather than merely accepting the repository configuration.
+
 ## Living Skill #001 Validation Kit
 
 - PR #43 merged the first zero-setup independent validation command into `main` as commit `0b9c8e4b3cabe18fbd53c91be9a49351a46115a6`: `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate`.
@@ -53,7 +62,7 @@ Last verified: 2026-07-16 (Asia/Shanghai)
 - PR #32 fixed the anonymous startup regression and was merged as commit `6da816ee69c8c621ba8b84044f9be16361332df5`. Missing credentials now enter degraded anonymous read-only mode, while an explicitly configured invalid token remains fatal.
 - Tag `v0.7.1` was published successfully through Trusted Publishing run `29085299535`; build, OIDC publish, exact PyPI install verification, and Pages refresh dispatch all passed.
 - A public-index-only environment reported `noosphere.__version__ == 0.7.1`. A separate exact-version `uvx --from noosphere-mcp==0.7.1 noosphere-mcp` process with `GITHUB_TOKEN` removed completed the MCP handshake and returned all 45 tools, including all five dynamic shared Skill tools.
-- MCP `serverInfo.version` currently reports the underlying `mcp` implementation version because FastMCP supplies its framework default. Distribution version verification is independent and correct; explicitly advertising the Noosphere package version is a non-blocking metadata follow-up.
+- Published versions through `0.8.1` report the underlying `mcp` implementation version because FastMCP supplies its framework default. Release candidate `0.8.2` explicitly advertises the Noosphere package version and verifies it through a real public-artifact MCP handshake.
 - The 13 foundational Skills are live in `shared_skills/registry.json` revision 1 and distributed by `noosphere-mcp==0.8.0`.
 - Issue #33 is the public coordination seed for the first real Skill: Android GitHub Device Flow browser handoff and polling recovery. It is explicitly excluded from source evidence and asks two independent developers to submit their own verified records.
 - Three maintainer-authored Skill Seeds were uploaded through the published `noosphere-mcp==0.7.1` `upload_consciousness` tool: R3F dense node picking (#35), dynamic shared Skill supply chain (#36), and public-release runtime smoke gating (#37). A second uploader run detected all three stable markers and created no duplicates.
@@ -126,4 +135,4 @@ Last verified: 2026-07-16 (Asia/Shanghai)
 
 1. Recruit independent developers through Issue #33 and Seeds #35-#37. A second GitHub publisher must submit separately reproduced evidence before a Seed or targeted update can become independently reproduced.
 2. Demonstrate one third-party Agent successfully reusing a Live Skill and record the exact-version outcome before claiming `outcome-proven`.
-3. Handle MCP implementation-version metadata, the existing Vite chunk warning, npm dependency advisories, and GitHub Actions Node runtime deprecation in separate maintenance work; none blocks the unified registry release.
+3. Handle the existing Vite chunk warning, npm dependency advisories, and GitHub Actions Node runtime deprecation in separate maintenance work; none blocks the unified registry release.

--- a/scripts/test_verify_pypi_release.py
+++ b/scripts/test_verify_pypi_release.py
@@ -1,13 +1,18 @@
 import tempfile
 import unittest
 import subprocess
+import json
 from pathlib import Path
 from unittest.mock import ANY, patch
 
 from scripts.verify_pypi_release import (
     REQUIRED_GROWTH_TOOLS,
+    build_mcp_probe_input,
     inspect_installed_release,
     install_release_to_target,
+    parse_mcp_probe_output,
+    probe_installed_mcp_runtime,
+    runtime_console_command,
     validate_release_json,
     verify_pypi_release,
     wait_for_installable_release,
@@ -90,6 +95,125 @@ class VerifyPypiReleaseTests(unittest.TestCase):
         self.assertIn("noosphere-mcp==0.6.8", command)
         run.assert_called_once_with(command, check=True)
 
+    def test_runtime_console_command_is_platform_aware(self):
+        runtime_dir = Path("runtime")
+
+        with patch("scripts.verify_pypi_release.os.name", "nt"):
+            self.assertEqual(
+                runtime_console_command(runtime_dir),
+                runtime_dir / "Scripts" / "noosphere-mcp.exe",
+            )
+
+        with patch("scripts.verify_pypi_release.os.name", "posix"):
+            self.assertEqual(
+                runtime_console_command(runtime_dir),
+                runtime_dir / "bin" / "noosphere-mcp",
+            )
+
+    def test_mcp_probe_input_initializes_before_listing_tools(self):
+        messages = [json.loads(line) for line in build_mcp_probe_input().splitlines()]
+
+        self.assertEqual(messages[0]["method"], "initialize")
+        self.assertEqual(messages[1]["method"], "notifications/initialized")
+        self.assertEqual(messages[2]["method"], "tools/list")
+
+    def test_parse_mcp_probe_output_requires_version_and_exact_tool_count(self):
+        stdout = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "result": {
+                            "serverInfo": {"name": "noosphere", "version": "0.8.2"},
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": {
+                            "tools": [{"name": f"tool_{index}"} for index in range(45)],
+                        },
+                    }
+                ),
+            ]
+        )
+
+        result = parse_mcp_probe_output(stdout, expected_version="0.8.2", expected_tool_count=45)
+
+        self.assertEqual(result["server_version"], "0.8.2")
+        self.assertEqual(result["runtime_tool_count"], 45)
+
+    def test_parse_mcp_probe_output_rejects_missing_tool_response(self):
+        stdout = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"serverInfo": {"name": "noosphere", "version": "0.8.2"}},
+            }
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "tools/list"):
+            parse_mcp_probe_output(stdout, expected_version="0.8.2", expected_tool_count=45)
+
+    def test_probe_installed_runtime_uses_anonymous_environment_and_timeout(self):
+        completed = subprocess.CompletedProcess(
+            ["noosphere-mcp"],
+            0,
+            stdout="\n".join(
+                [
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "result": {
+                                "serverInfo": {"name": "noosphere", "version": "0.8.2"},
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 2,
+                            "result": {
+                                "tools": [{"name": f"tool_{index}"} for index in range(45)],
+                            },
+                        }
+                    ),
+                ]
+            ),
+            stderr="",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_dir = Path(tmp)
+            command = runtime_console_command(runtime_dir)
+            command.parent.mkdir(parents=True)
+            command.touch()
+
+            with (
+                patch("scripts.verify_pypi_release.subprocess.run", return_value=completed) as run,
+                patch.dict(
+                    "scripts.verify_pypi_release.os.environ",
+                    {"GITHUB_TOKEN": "secret", "GH_TOKEN": "secret", "PATH": "test-path"},
+                    clear=True,
+                ),
+            ):
+                result = probe_installed_mcp_runtime(
+                    runtime_dir,
+                    expected_version="0.8.2",
+                    expected_tool_count=45,
+                    timeout_seconds=30,
+                )
+
+        kwargs = run.call_args.kwargs
+        self.assertNotIn("GITHUB_TOKEN", kwargs["env"])
+        self.assertNotIn("GH_TOKEN", kwargs["env"])
+        self.assertEqual(kwargs["timeout"], 30)
+        self.assertEqual(result["runtime_tool_count"], 45)
+
     def test_wait_for_pypi_project_latest_requires_latest_version(self):
         stale_json = {
             "info": {"version": "0.6.4"},
@@ -138,12 +262,15 @@ class VerifyPypiReleaseTests(unittest.TestCase):
             ],
         }
         installed = {"version": "0.6.8", "tool_count": 40, "growth_tools": REQUIRED_GROWTH_TOOLS}
+        runtime = {"server_version": "0.6.8", "runtime_tool_count": 40, "runtime_seconds": 1.5}
 
         with (
             patch("scripts.verify_pypi_release.wait_for_pypi_release", return_value=release_json) as wait,
             patch("scripts.verify_pypi_release.wait_for_pypi_project_latest", return_value=release_json) as wait_latest,
             patch("scripts.verify_pypi_release.wait_for_installable_release") as install,
             patch("scripts.verify_pypi_release.inspect_installed_release", return_value=installed) as inspect,
+            patch("scripts.verify_pypi_release.install_runtime_environment") as install_runtime,
+            patch("scripts.verify_pypi_release.probe_installed_mcp_runtime", return_value=runtime) as probe_runtime,
         ):
             result = verify_pypi_release("noosphere-mcp", "0.6.8", attempts=1, delay_seconds=0, expected_tool_count=40)
 
@@ -151,8 +278,11 @@ class VerifyPypiReleaseTests(unittest.TestCase):
         wait_latest.assert_called_once_with("noosphere-mcp", "0.6.8", 1, 0)
         install.assert_called_once_with("noosphere-mcp", "0.6.8", ANY, 1, 0)
         inspect.assert_called_once()
+        install_runtime.assert_called_once()
+        probe_runtime.assert_called_once()
         self.assertEqual(result["version"], "0.6.8")
         self.assertEqual(result["tool_count"], 40)
+        self.assertEqual(result["runtime_tool_count"], 40)
         self.assertEqual(result["latest_files"], result["files"])
 
 

--- a/scripts/verify_pypi_release.py
+++ b/scripts/verify_pypi_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -26,6 +27,7 @@ REQUIRED_GROWTH_TOOLS = [
     "growth_flywheel",
     "launch_preflight",
 ]
+MCP_PROBE_PROTOCOL_VERSION = "2024-11-05"
 
 
 def read_project_version(pyproject_path: Path = REPO_ROOT / "sdk" / "pyproject.toml") -> str:
@@ -134,6 +136,169 @@ def wait_for_installable_release(
     raise RuntimeError(f"PyPI release {project}=={version} did not become pip-installable: {last_error}")
 
 
+def runtime_python_command(runtime_dir: Path) -> Path:
+    if os.name == "nt":
+        return runtime_dir / "Scripts" / "python.exe"
+    return runtime_dir / "bin" / "python"
+
+
+def runtime_console_command(runtime_dir: Path) -> Path:
+    if os.name == "nt":
+        return runtime_dir / "Scripts" / "noosphere-mcp.exe"
+    return runtime_dir / "bin" / "noosphere-mcp"
+
+
+def install_runtime_environment(
+    project: str,
+    version: str,
+    runtime_dir: Path,
+    python_executable: str = sys.executable,
+) -> None:
+    subprocess.run(
+        [python_executable, "-m", "venv", str(runtime_dir)],
+        check=True,
+    )
+    subprocess.run(
+        [
+            str(runtime_python_command(runtime_dir)),
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-cache-dir",
+            f"{project}=={version}",
+        ],
+        check=True,
+    )
+
+
+def build_mcp_probe_input() -> str:
+    messages = [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": MCP_PROBE_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "noosphere-release-verifier",
+                    "version": "1.0",
+                },
+            },
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {},
+        },
+    ]
+    return "".join(json.dumps(message, separators=(",", ":")) + "\n" for message in messages)
+
+
+def parse_mcp_probe_output(
+    stdout: str,
+    *,
+    expected_version: str,
+    expected_tool_count: int,
+) -> dict:
+    payloads: list[dict] = []
+    for line in stdout.splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            payloads.append(payload)
+
+    initialize = next((payload for payload in payloads if payload.get("id") == 1), None)
+    if not initialize:
+        raise RuntimeError("Published MCP runtime did not return an initialize response")
+    if "error" in initialize:
+        raise RuntimeError(f"Published MCP initialize failed: {initialize['error']}")
+
+    server_info = initialize.get("result", {}).get("serverInfo", {})
+    server_version = str(server_info.get("version", ""))
+    if server_version != expected_version:
+        raise RuntimeError(
+            f"Published MCP serverInfo.version {server_version!r}, expected {expected_version!r}"
+        )
+
+    tool_response = next((payload for payload in payloads if payload.get("id") == 2), None)
+    if not tool_response:
+        raise RuntimeError("Published MCP runtime did not return a tools/list response")
+    if "error" in tool_response:
+        raise RuntimeError(f"Published MCP tools/list failed: {tool_response['error']}")
+
+    tools = tool_response.get("result", {}).get("tools")
+    if not isinstance(tools, list):
+        raise RuntimeError("Published MCP tools/list response did not contain a tools array")
+    if len(tools) != expected_tool_count:
+        raise RuntimeError(
+            f"Published MCP runtime exposed {len(tools)} tools, expected {expected_tool_count}"
+        )
+
+    return {
+        "server_version": server_version,
+        "runtime_tool_count": len(tools),
+    }
+
+
+def probe_installed_mcp_runtime(
+    runtime_dir: Path,
+    *,
+    expected_version: str,
+    expected_tool_count: int,
+    timeout_seconds: float = 30.0,
+) -> dict:
+    command = runtime_console_command(runtime_dir)
+    if not command.is_file():
+        raise RuntimeError(f"Published MCP console entry point is missing: {command}")
+
+    env = os.environ.copy()
+    env.pop("GITHUB_TOKEN", None)
+    env.pop("GH_TOKEN", None)
+
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            [str(command)],
+            input=build_mcp_probe_input(),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        raise RuntimeError(
+            f"Published MCP initialize + tools/list timed out after {timeout_seconds:.1f}s: "
+            f"{stderr[-500:]}"
+        ) from exc
+
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Published MCP runtime exited with {completed.returncode}: {completed.stderr[-1000:]}"
+        )
+
+    result = parse_mcp_probe_output(
+        completed.stdout,
+        expected_version=expected_version,
+        expected_tool_count=expected_tool_count,
+    )
+    result["runtime_seconds"] = round(time.monotonic() - started, 3)
+    return result
+
+
 def inspect_installed_release(
     target_dir: Path,
     expected_version: str,
@@ -211,8 +376,17 @@ def verify_pypi_release(project: str, version: str, attempts: int, delay_seconds
 
     temp_dir = Path(tempfile.mkdtemp(prefix="noosphere-pypi-verify-"))
     try:
-        wait_for_installable_release(project, version, temp_dir, attempts, delay_seconds)
-        installed = inspect_installed_release(temp_dir, version, expected_tool_count=expected_tool_count)
+        inspect_dir = temp_dir / "inspect"
+        wait_for_installable_release(project, version, inspect_dir, attempts, delay_seconds)
+        installed = inspect_installed_release(inspect_dir, version, expected_tool_count=expected_tool_count)
+
+        runtime_dir = temp_dir / "runtime"
+        install_runtime_environment(project, version, runtime_dir)
+        runtime = probe_installed_mcp_runtime(
+            runtime_dir,
+            expected_version=version,
+            expected_tool_count=expected_tool_count,
+        )
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
 
@@ -222,6 +396,7 @@ def verify_pypi_release(project: str, version: str, attempts: int, delay_seconds
         "files": filenames,
         "latest_files": latest_filenames,
         **installed,
+        **runtime,
     }
 
 
@@ -240,7 +415,8 @@ def main(argv: list[str] | None = None) -> int:
     result = verify_pypi_release(args.project, args.version, args.attempts, args.delay_seconds, args.tool_count)
     print(
         f"Verified {result['project']}=={result['version']}: "
-        f"{result['tool_count']} MCP tools, growth ledger tools, noosphere-query and "
+        f"{result['runtime_tool_count']} MCP tools via initialize + tools/list in "
+        f"{result['runtime_seconds']:.3f}s; growth ledger tools, noosphere-query and "
         "noosphere-validate present."
     )
     return 0

--- a/sdk/noosphere/__init__.py
+++ b/sdk/noosphere/__init__.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
     from noosphere.client import Noosphere
 
 __all__ = ["Noosphere"]
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 
 def __getattr__(name: str):

--- a/sdk/noosphere/engine/vector_store.py
+++ b/sdk/noosphere/engine/vector_store.py
@@ -10,6 +10,7 @@ No external vector database required — GitHub is the database.
 from __future__ import annotations
 
 import logging
+import math
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -41,7 +42,8 @@ class VectorStore:
     - Vectors are stored as JSON arrays in GitHub repo files (no external DB)
     - CI computes embeddings via Gemini API during consciousness promotion
     - MCP loads all vectors into memory on startup for sub-millisecond search
-    - Graceful degradation: if numpy unavailable or no vectors, returns empty
+    - NumPy accelerates larger indexes; the standard-library path preserves
+      exact cosine search for lightweight installations
     """
 
     def __init__(self):
@@ -58,8 +60,8 @@ class VectorStore:
 
     @property
     def available(self) -> bool:
-        """Whether vector search is available (numpy installed + vectors loaded)."""
-        return _get_numpy() is not None and self.size > 0
+        """Whether vector search has vectors loaded."""
+        return self.size > 0
 
     def clear(self) -> None:
         """Clear all stored vectors."""
@@ -154,19 +156,32 @@ class VectorStore:
         return loaded
 
     def _build_matrix(self) -> None:
-        """Build the NumPy matrix from raw vectors (lazy, only when needed)."""
-        np = _get_numpy()
-        if np is None or not self._vectors:
+        """Build a normalized search matrix lazily."""
+        if not self._vectors:
             self._matrix = None
             return
 
+        np = _get_numpy()
+
         try:
-            self._matrix = np.array(self._vectors, dtype=np.float32)
-            # L2 normalize for cosine similarity via dot product
-            norms = np.linalg.norm(self._matrix, axis=1, keepdims=True)
-            # Avoid division by zero
-            norms = np.where(norms == 0, 1, norms)
-            self._matrix = self._matrix / norms
+            if np is not None:
+                self._matrix = np.array(self._vectors, dtype=np.float32)
+                # L2 normalize for cosine similarity via dot product
+                norms = np.linalg.norm(self._matrix, axis=1, keepdims=True)
+                # Avoid division by zero
+                norms = np.where(norms == 0, 1, norms)
+                self._matrix = self._matrix / norms
+            else:
+                dimensions = {len(vector) for vector in self._vectors}
+                if len(dimensions) != 1:
+                    raise ValueError("all stored vectors must have the same dimension")
+                self._matrix = []
+                for vector in self._vectors:
+                    norm = math.sqrt(math.fsum(float(value) ** 2 for value in vector))
+                    if norm == 0:
+                        self._matrix.append([0.0 for _ in vector])
+                    else:
+                        self._matrix.append([float(value) / norm for value in vector])
             self._dirty = False
         except Exception as e:
             logger.warning(f"VectorStore: failed to build matrix: {e}")
@@ -194,8 +209,7 @@ class VectorStore:
         Returns:
             List of (similarity_score, doc_id, metadata) tuples, sorted by score desc
         """
-        np = _get_numpy()
-        if np is None or not self._vectors:
+        if not self._vectors:
             return []
 
         if self._dirty or self._matrix is None:
@@ -205,19 +219,44 @@ class VectorStore:
             return []
 
         try:
-            # Normalize query vector
-            q = np.array(query_vector, dtype=np.float32)
-            q_norm = np.linalg.norm(q)
-            if q_norm == 0:
-                return []
-            q = q / q_norm
-
-            # Compute cosine similarities (dot product of normalized vectors)
-            similarities = self._matrix @ q
+            np = _get_numpy()
+            if np is not None:
+                q = np.array(query_vector, dtype=np.float32)
+                q_norm = np.linalg.norm(q)
+                if q_norm == 0:
+                    return []
+                q = q / q_norm
+                similarities = self._matrix @ q
+                ranked_indices = np.argsort(similarities)[::-1]
+            else:
+                if len(query_vector) != len(self._matrix[0]):
+                    return []
+                q_norm = math.sqrt(
+                    math.fsum(float(value) ** 2 for value in query_vector)
+                )
+                if q_norm == 0:
+                    return []
+                normalized_query = [
+                    float(value) / q_norm for value in query_vector
+                ]
+                similarities = [
+                    math.fsum(
+                        stored * query
+                        for stored, query in zip(
+                            vector, normalized_query, strict=True
+                        )
+                    )
+                    for vector in self._matrix
+                ]
+                ranked_indices = sorted(
+                    range(len(similarities)),
+                    key=similarities.__getitem__,
+                    reverse=True,
+                )
 
             # Get top candidates (more than top_k to allow for filtering)
             candidate_count = min(len(similarities), top_k * 3)
-            top_indices = np.argsort(similarities)[::-1][:candidate_count]
+            top_indices = ranked_indices[:candidate_count]
 
             results = []
             for idx in top_indices:

--- a/sdk/noosphere/noosphere_mcp.py
+++ b/sdk/noosphere/noosphere_mcp.py
@@ -48,6 +48,7 @@ from urllib.parse import parse_qsl, urlsplit
 import httpx
 from mcp.server.fastmcp import FastMCP
 
+from noosphere import __version__
 from noosphere.engine.memory_integrity import (
     canonicalize_permanent_entries,
     parse_tombstoned_issue_numbers,
@@ -1154,6 +1155,10 @@ mcp = FastMCP(
         "so that future Agents can understand the scenario in which this thought was born."
     ),
 )
+# FastMCP 1.x otherwise falls back to the SDK distribution version in
+# initialize.serverInfo.version. Directory scanners and clients need the
+# Noosphere release version that matches server.json and PyPI.
+mcp._mcp_server.version = __version__
 
 
 # ────────────────── Text Utilities ──────────────────

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "noosphere-mcp"
-version = "0.8.1"
+version = "0.8.2"
 description = "🧠 Noosphere — 集体意识网络 MCP Server，直连 GitHub 意识仓库"
 readme = "../README.md"
 requires-python = ">=3.10"
@@ -25,13 +25,15 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "mcp>=1.3.0",
+    "mcp>=1.27,<2",
     "httpx>=0.28.0",
-    "sentence-transformers>=2.2.0",
-    "numpy>=1.24.0",
 ]
 
 [project.optional-dependencies]
+semantic = [
+    "sentence-transformers>=2.2.0",
+    "numpy>=1.24.0",
+]
 dev = [
     "build>=1.2.2",
     "pytest>=8.0.0",

--- a/sdk/server.json
+++ b/sdk/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "JinNing6/Noosphere"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "noosphere-mcp",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/sdk/tests/test_release_boundary.py
+++ b/sdk/tests/test_release_boundary.py
@@ -57,6 +57,25 @@ def test_release_exposes_deterministic_living_skill_validation_command():
     assert (SDK_ROOT / "noosphere" / "validation_kits" / "public_artifact_runtime_smoke_gate.py").is_file()
 
 
+def test_default_runtime_excludes_optional_semantic_model_stack():
+    project = _project_metadata()["project"]
+
+    assert project["dependencies"] == [
+        "mcp>=1.27,<2",
+        "httpx>=0.28.0",
+    ]
+    assert project["optional-dependencies"]["semantic"] == [
+        "sentence-transformers>=2.2.0",
+        "numpy>=1.24.0",
+    ]
+
+
+def test_mcp_handshake_advertises_noosphere_distribution_version():
+    from noosphere.noosphere_mcp import mcp
+
+    assert mcp._mcp_server.version == _package_version()
+
+
 def test_publish_workflow_uses_single_release_trigger_with_trusted_publishing_quality_gates():
     workflow = (REPO_ROOT / ".github" / "workflows" / "publish-pypi.yml").read_text(encoding="utf-8")
 
@@ -82,6 +101,7 @@ def test_publish_workflow_uses_single_release_trigger_with_trusted_publishing_qu
     assert "verify-pypi:" in workflow
     assert "needs: publish-pypi" in workflow
     assert "python scripts/verify_pypi_release.py --tool-count 45" in workflow
+    assert "initialize + tools/list" in workflow
     assert "refresh-pages-proof:" in workflow
     assert "needs: verify-pypi" in workflow
     assert "actions: write" in workflow

--- a/sdk/tests/test_vector_store.py
+++ b/sdk/tests/test_vector_store.py
@@ -6,7 +6,6 @@ cross-modal consciousness resonance in Noosphere.
 """
 
 import pytest
-import math
 
 
 class TestVectorStore:
@@ -144,6 +143,20 @@ class TestVectorStore:
         vs.add_vector("doc:1", [1.0, 0.0], metadata={"payload": {}})
         results = vs.search([0.0, 0.0])
         assert results == []
+
+    def test_standard_library_fallback_without_numpy(self, monkeypatch):
+        """Lightweight installs retain cosine search without NumPy."""
+        from noosphere.engine import vector_store
+
+        monkeypatch.setattr(vector_store, "_get_numpy", lambda: None)
+        vs = vector_store.VectorStore()
+        vs.add_vector("close", [1.0, 0.0], metadata={"payload": {}})
+        vs.add_vector("far", [0.0, 1.0], metadata={"payload": {}})
+
+        results = vs.search([1.0, 0.0], min_similarity=0.0)
+
+        assert [doc_id for _, doc_id, _ in results] == ["close", "far"]
+        assert results[0][0] == pytest.approx(1.0)
 
     def test_load_from_payloads(self):
         """load_from_payloads should extract embeddings from issues and files."""

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "JinNing6/Noosphere"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "noosphere-mcp",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- move the local Sentence Transformers stack behind an explicit `semantic` extra so directory scanners can cold-start the default MCP runtime
- preserve precomputed vector search without NumPy through a standard-library cosine fallback
- advertise the Noosphere package version during MCP initialization and pin the supported MCP 1.x boundary
- strengthen the PyPI verifier to cold-install the public artifact and require anonymous `initialize + tools/list`

## Root cause
Glama's public record returned no tools because a clean `noosphere-mcp==0.8.1` install pulled Torch, Transformers, SciPy, NumPy, and Sentence Transformers. Cold import took 72.67s and the full handshake exceeded 244s, while the same installed environment returned all 45 tools in 0.81s when warm.

## Verification
- `python -m pytest sdk/tests -q` -> 206 passed
- repository script tests -> 25 passed
- `node --test .github/scripts/*.test.cjs` -> 93 passed
- Ruff critical and focused checks passed
- clean local Wheel install resolved 34 lightweight distributions with no Torch/Transformers/SciPy/NumPy/Sentence Transformers
- anonymous `initialize + tools/list` -> 45 tools in 0.86s, `serverInfo.version=0.8.2`