### PR TITLE
Launch Living Skill #001 with a 60-second validation path

### DIFF
--- a/.github/ISSUE_TEMPLATE/validate-skill.yml
+++ b/.github/ISSUE_TEMPLATE/validate-skill.yml
@@ -16,13 +16,13 @@ body:
         uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
         ```
 
-        No project, GitHub token, MCP configuration, or package-index account is required. Review the generated evidence before submitting it.
+        No project, GitHub token, MCP configuration, or package-index account is required. The command prints a prefilled submission link. Open it, review the generated evidence, confirm the declaration, and submit.
 
   - type: textarea
     id: generated_validation_evidence
     attributes:
       label: Generated validation evidence
-      description: Paste the complete output block, including the CONSCIOUSNESS_PAYLOAD markers.
+      description: This field is prefilled by the validation command. If you opened the form manually, paste the complete output block including the CONSCIOUSNESS_PAYLOAD markers.
       placeholder: "<!-- CONSCIOUSNESS_PAYLOAD_START --> ... <!-- CONSCIOUSNESS_PAYLOAD_END -->"
       render: markdown
     validations:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       shared: ${{ steps.filter.outputs.shared }}
       glama: ${{ steps.filter.outputs.glama }}
+      validation: ${{ steps.filter.outputs.validation }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,6 +58,12 @@ jobs:
             echo "glama=true" >> "$GITHUB_OUTPUT"
           else
             echo "glama=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if grep -Eq '^(sdk/noosphere/validation_|sdk/tests/test_validation_cli\.py|examples/reproductions/public-artifact-runtime-smoke-gate/|\.github/ISSUE_TEMPLATE/validate-skill\.yml|\.github/workflows/ci\.yml|scripts/(verify_pypi_release|test_verify_pypi_release)\.py)' /tmp/changed_files; then
+            echo "validation=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "validation=false" >> "$GITHUB_OUTPUT"
           fi
 
   frontend-check:
@@ -163,6 +170,46 @@ jobs:
           python -m unittest scripts.test_validate_shared_skills scripts.test_migrate_consciousness_promotions
           python scripts/validate_shared_skills.py
           python scripts/migrate_consciousness_promotions.py --check
+
+  validation-kit-matrix:
+    name: 60s Validation Kit (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.validation == 'true'
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install the validation command
+        run: pip install -e "./sdk[dev]"
+
+      - name: Run the exact token-free validation path
+        env:
+          GITHUB_TOKEN: ''
+          GH_TOKEN: ''
+        run: noosphere-validate public-artifact-runtime-smoke-gate --format json --output validation-result.json
+
+      - name: Enforce the 60-second and prefilled-form contracts
+        run: >-
+          python -c "import json; from pathlib import Path; from urllib.parse import parse_qs, urlsplit;
+          result=json.loads(Path('validation-result.json').read_text(encoding='utf-8'));
+          query=parse_qs(urlsplit(result['submission_url']).query);
+          assert result['passed'] is True;
+          assert result['duration_seconds'] < 60;
+          assert query['template'] == ['validate-skill.yml'];
+          assert 'CONSCIOUSNESS_PAYLOAD_START' in query['generated_validation_evidence'][0];
+          print(f\"Validated in {result['duration_seconds']:.2f}s with a prefilled evidence link\")"
 
   glama-container-check:
     name: Glama Container MCP Discovery

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
             echo "glama=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if grep -Eq '^(sdk/noosphere/validation_|sdk/tests/test_validation_cli\.py|examples/reproductions/public-artifact-runtime-smoke-gate/|\.github/ISSUE_TEMPLATE/validate-skill\.yml|\.github/workflows/ci\.yml|scripts/(verify_pypi_release|test_verify_pypi_release)\.py)' /tmp/changed_files; then
+          if grep -Eq '^(sdk/noosphere/validation_|sdk/tests/test_validation_cli\.py|examples/reproductions/public-artifact-runtime-smoke-gate/|\.github/ISSUE_TEMPLATE/validate-skill\.yml|\.github/workflows/ci\.yml|scripts/(check_validation_result|test_check_validation_result|verify_pypi_release|test_verify_pypi_release)\.py)' /tmp/changed_files; then
             echo "validation=true" >> "$GITHUB_OUTPUT"
           else
             echo "validation=false" >> "$GITHUB_OUTPUT"
@@ -116,7 +116,7 @@ jobs:
       - name: SDK and repository tests
         run: |
           python -m pytest sdk/tests
-          python -m unittest scripts.test_validate_shared_skills scripts.test_migrate_consciousness_promotions scripts.test_launch_surface
+          python -m unittest scripts.test_validate_shared_skills scripts.test_migrate_consciousness_promotions scripts.test_launch_surface scripts.test_check_validation_result
 
       - name: Syntax and undefined-name gate
         run: |
@@ -201,15 +201,7 @@ jobs:
         run: noosphere-validate public-artifact-runtime-smoke-gate --format json --output validation-result.json
 
       - name: Enforce the 60-second and prefilled-form contracts
-        run: >-
-          python -c "import json; from pathlib import Path; from urllib.parse import parse_qs, urlsplit;
-          result=json.loads(Path('validation-result.json').read_text(encoding='utf-8'));
-          query=parse_qs(urlsplit(result['submission_url']).query);
-          assert result['passed'] is True;
-          assert result['duration_seconds'] < 60;
-          assert query['template'] == ['validate-skill.yml'];
-          assert 'CONSCIOUSNESS_PAYLOAD_START' in query['generated_validation_evidence'][0];
-          print(f\"Validated in {result['duration_seconds']:.2f}s with a prefilled evidence link\")"
+        run: python scripts/check_validation_result.py validation-result.json
 
   glama-container-check:
     name: Glama Container MCP Discovery

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: .
         run: |
           node --test .github/scripts/*.test.cjs
-          python -m unittest scripts.test_validate_shared_skills scripts.test_migrate_consciousness_promotions scripts.test_launch_surface
+          python -m unittest scripts.test_validate_shared_skills scripts.test_migrate_consciousness_promotions scripts.test_launch_surface scripts.test_check_validation_result
           python scripts/validate_shared_skills.py
           python scripts/migrate_consciousness_promotions.py --check
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 **Stop solving the same bug twice.** One Agent discovers a failure pattern; every
 future Agent can retrieve the evidence, apply the fix, and report whether it worked.
 
-[![Live Skills](https://img.shields.io/badge/Live_Skills-13-8d7cff?style=for-the-badge)](docs/live-skills.md)
-[![Verified Seeds](https://img.shields.io/badge/Verified_Seeds-3-2ea043?style=for-the-badge)](docs/founding-debug-memories.md)
+[![Live Skills](https://img.shields.io/badge/Live_Skills-14-8d7cff?style=for-the-badge)](docs/live-skills.md)
+[![Verified Seeds](https://img.shields.io/badge/Verified_Seeds-2-2ea043?style=for-the-badge)](docs/founding-debug-memories.md)
 [![MCP Tools](https://img.shields.io/badge/MCP_Tools-45-0969da?style=for-the-badge)](sdk/noosphere/noosphere_mcp.py)
 [![PyPI](https://img.shields.io/pypi/v/noosphere-mcp?style=for-the-badge&logo=pypi&logoColor=white)](https://pypi.org/project/noosphere-mcp/)
 
@@ -42,9 +42,9 @@ uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
 ```
 
 No repository clone, personal project, GitHub token, MCP configuration, or package-index
-account is required. The command generates reviewable evidence with exact artifact
-digests; paste the complete marked block into the
-[Skill validation form](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml).
+account is required. The command finishes under a 60-second gate and generates reviewable
+evidence with exact artifact digests plus a prefilled GitHub submission link. Review the
+evidence, confirm the declaration, and submit without copying JSON manually.
 This is the shortest path to become an independent validator of the first community
 Living Skill.
 
@@ -54,19 +54,19 @@ Living Skill.
 
 The 20-second demo is reconstructed from the real, verified engineering record in
 [Issue #35](https://github.com/JinNing6/Noosphere/issues/35). It shows a **Seed Memory**
-that has not yet reached independent reproduction. The registry also contains 13
-foundational Live Skills at the explicit `maintainer-validated` trust level.
+that has not yet reached independent reproduction. The registry now contains 14
+maintainer-validated Live Skills, including Living Skill #001.
 
 | Inspect the live system | Path |
 |---|---|
 | Immutable Skill registry | [`shared_skills/registry.json`](shared_skills/registry.json) |
-| 13 Live engineering Skills | [Catalog](docs/live-skills.md) · [active mirrors](shared_skills/active/) |
+| 14 Live engineering Skills | [Catalog](docs/live-skills.md) · [active mirrors](shared_skills/active/) |
 | Immutable releases | [`shared_skills/releases/<version>/<name>/SKILL.md`](shared_skills/releases/) |
 | Founding evidence | [Issues #35](https://github.com/JinNing6/Noosphere/issues/35), [#36](https://github.com/JinNing6/Noosphere/issues/36), [#37](https://github.com/JinNing6/Noosphere/issues/37) |
 | Supply-chain protocol | [`SKILLS_PROTOCOL.md`](SKILLS_PROTOCOL.md) |
 
-**Next contribution:** run the validation command above and submit its generated block
-through the dedicated [Skill validation form](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml).
+**Next contribution:** run the validation command above, open its generated prefilled link,
+review the evidence, and submit one independent result.
 For a different verified engineering lesson, keep using the general
 [memory contribution form](https://github.com/JinNing6/Noosphere/issues/new?template=consciousness-upload.yml).
 **Shared it publicly? Record proof:** use the
@@ -94,7 +94,7 @@ uvx --from 'noosphere-mcp[semantic]' noosphere-mcp
 ```
 
 > [!IMPORTANT]
-> Version `v0.8.2` keeps the default MCP runtime scanner-friendly by making the local semantic model optional, pins the stable MCP SDK 1.x boundary, and verifies every public release with a real anonymous `initialize + tools/list` handshake. It retains the zero-setup validation kit, unified live registry, and anonymous read-only consultation. Anonymous queries use
+> Version `v0.8.3` adds the first immutable Living Skill and turns the validation result into a prefilled, token-free GitHub handoff. Windows, Linux, and macOS CI enforce the same sub-60-second fixture, and the public release verifier executes it from the exact PyPI installation. The default MCP runtime remains scanner-friendly, lightweight, and anonymously readable. Anonymous queries use
 > the repository's canonical public index; authenticated sessions retain the fresher Issues + permanent
 > file search path. Install the `semantic` extra for local multilingual vector ranking;
 > otherwise search degrades to BM25. Write operations always require GitHub authentication.
@@ -107,10 +107,10 @@ failure -> verified memory -> independent reproduction -> deterministic candidat
         -> execution outcome -> update or reviewed rollback
 ```
 
-Noosphere does not auto-execute community prompts. Its 13 foundational Skills are live as
+Noosphere does not auto-execute community prompts. Its 14 maintainer-validated Live Skills are
 immutable `1.0.0` releases with maintainer provenance and SHA-256 verification. New
 community Skills and updates require structured root-cause evidence, two independent
-publishers, maintainer review, outcome feedback, and rollback. The 3 verified Seeds have
+publishers, maintainer review, outcome feedback, and rollback. The 2 remaining verified Seeds have
 not yet crossed that independent-reproduction gate.
 
 ## Explore the network
@@ -282,7 +282,7 @@ Ordinary Skill files teach one Agent a workflow. Noosphere gives every Skill one
 
 The public MCP surface is `list_shared_skills`, `get_shared_skill`, and `check_skill_updates`. Authenticated users can submit idempotent execution feedback through `record_skill_outcome`; trusted review records it in the public outcome ledger. Only an independent success with public evidence advances proven reuse; partial or failed outcomes mark an update-needed boundary without rewriting immutable instructions. Rollback requests remain separately review-gated through `request_shared_skill_withdrawal`. See [the protocol and trust boundary](SKILLS_PROTOCOL.md).
 
-The registry starts with 13 maintainer-authored foundational Skills at `maintainer-validated`. Noosphere will not claim independent reproduction until two independent publishers provide structured evidence, a deterministic candidate is generated, and a maintainer approves the immutable next release.
+The registry contains 14 Live Skills at `maintainer-validated`. Noosphere will not claim independent reproduction until two independent publishers provide structured evidence, a deterministic candidate is generated, and a maintainer approves the immutable next release.
 
 ---
 
@@ -317,7 +317,7 @@ What the plugin gives Codex:
 | `consult_noosphere` via MCP | Search shared debugging memories before spending time on a bug. |
 | `upload_consciousness` via MCP | Publish verified warnings, patterns, and decisions after a fix. |
 | Dynamic shared Skill tools | Discover approved releases, verify exact digests, check updates, report outcomes, and request reviewed rollback. |
-| 13 Live engineering Skills | Discover and retrieve versioned debugging, CI, release, frontend, infrastructure, backend, security, and Noosphere workflows from the shared registry. [Browse the catalog.](docs/live-skills.md) |
+| 14 Live engineering Skills | Discover and retrieve versioned debugging, CI, release, frontend, infrastructure, backend, security, and Noosphere workflows from the shared registry. [Browse the catalog.](docs/live-skills.md) |
 
 **Install first. Spread by real bug saves. Let every fixed failure become distribution.**
 
@@ -347,7 +347,7 @@ The Claude plugin bundles:
 |---|---|
 | `mcpServers.noosphere` | Starts `uvx noosphere-mcp` automatically when the plugin is enabled. |
 | `userConfig.github_token` | Optional sensitive GitHub token for uploads and higher rate limits; public consultation works without manual JSON edits. |
-| 13 Live engineering Skills | The same versioned registry available to Codex, Claude Code, and every MCP client without plugin-local copies. [Browse the catalog.](docs/live-skills.md) |
+| 14 Live engineering Skills | The same versioned registry available to Codex, Claude Code, and every MCP client without plugin-local copies. [Browse the catalog.](docs/live-skills.md) |
 | Dynamic shared Skill MCP tools | Lists, retrieves, updates, reports, and requests rollback through the versioned registry. |
 | `/noosphere:noosphere-consult` and `/noosphere:noosphere-upload` | Manual slash commands for explicit memory search and upload. |
 
@@ -850,7 +850,7 @@ Unlike the old world, the Community of Consciousness continuously evolves. When 
 | `uvx` / `npx` (Recommended) | ⚡ **Auto Evolve** | Just restart the IDE / MCP client. `uvx` automatically pulls the latest version on launch |
 | `pip install` (Manual) | 🔧 Manual Upgrade | Execute `pip install --upgrade noosphere-mcp`, then restart IDE |
 
-Maintainer release path for the unified live registry: publish a semantic GitHub Release such as `v0.8.2` from the intended `main` commit. The single `release.published` trigger runs `.github/workflows/publish-pypi.yml`, which builds `noosphere-mcp` with SDK, workflow, validation-kit, and shared Skill supply-chain tests, then publishes through PyPI Trusted Publishing/OIDC without a stored `PYPI_TOKEN`; after the PyPI verifier performs a real anonymous `initialize + tools/list` handshake against a clean installed runtime, it dispatches `.github/workflows/deploy-pages.yml` on `main` so GitHub Pages refreshes the public evidence and Skill indexes. Do not push the release tag separately: creating a GitHub Release also creates its tag, and two configured triggers would race to publish the same immutable PyPI version. After PyPI shows `0.8.2`, `uvx noosphere-mcp`, `uvx --from noosphere-mcp noosphere-query "your error"`, `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate`, and `pip install --upgrade noosphere-mcp` deliver the 45 MCP tools, 13 live Skill registry entries, zero-configuration read-only query, and the deterministic independent-validation path.
+Maintainer release path for the unified live registry: publish a semantic GitHub Release such as `v0.8.3` from the intended `main` commit. The single `release.published` trigger runs `.github/workflows/publish-pypi.yml`, which builds `noosphere-mcp` with SDK, workflow, validation-kit, and shared Skill supply-chain tests, then publishes through PyPI Trusted Publishing/OIDC without a stored `PYPI_TOKEN`; after the PyPI verifier performs a real anonymous `initialize + tools/list` handshake and the sub-60-second validation command against a clean installed runtime, it dispatches `.github/workflows/deploy-pages.yml` on `main` so GitHub Pages refreshes the public evidence and Skill indexes. Do not push the release tag separately: creating a GitHub Release also creates its tag, and two configured triggers would race to publish the same immutable PyPI version. After PyPI shows `0.8.3`, `uvx noosphere-mcp`, `uvx --from noosphere-mcp noosphere-query "your error"`, `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate`, and `pip install --upgrade noosphere-mcp` deliver the 45 MCP tools, 14 live Skill registry entries, zero-configuration read-only query, and the prefilled independent-validation path.
 
 > 💡 **How to check**: Look at your MCP config. If `command` is `"uvx"`, you are in Auto Evolve mode; if `"python"`, you are in Manual mode.
 >

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,8 +9,8 @@
 **不要让每个 Agent 重复解决同一个 Bug。** 一个 Agent 发现失败模式，后续 Agent
 可以检索证据、应用修复，并反馈这次复用是否真的有效。
 
-[![实时 Skills](https://img.shields.io/badge/实时_Skills-13-8d7cff?style=for-the-badge)](docs/live-skills.md)
-[![已验证种子](https://img.shields.io/badge/已验证种子-3-2ea043?style=for-the-badge)](docs/founding-debug-memories.md)
+[![实时 Skills](https://img.shields.io/badge/实时_Skills-14-8d7cff?style=for-the-badge)](docs/live-skills.md)
+[![已验证种子](https://img.shields.io/badge/已验证种子-2-2ea043?style=for-the-badge)](docs/founding-debug-memories.md)
 [![MCP 工具](https://img.shields.io/badge/MCP_工具-45-0969da?style=for-the-badge)](sdk/noosphere/noosphere_mcp.py)
 [![PyPI](https://img.shields.io/pypi/v/noosphere-mcp?style=for-the-badge&logo=pypi&logoColor=white)](https://pypi.org/project/noosphere-mcp/)
 
@@ -40,28 +40,26 @@ uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
 ```
 
 无需克隆仓库、准备个人项目、配置 GitHub Token、理解 MCP 协议或注册包索引账号。
-命令会生成包含精确制品摘要的可审查证据；将完整标记块粘贴到
-[Skill 验证表单](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml)，
-即可成为首个社区 Living Skill 的独立验证者。
+命令受 60 秒硬门禁约束，并直接生成已预填完整证据的 GitHub 链接；审核内容、
+勾选声明并提交即可，无需手工复制 JSON。
 
 <div align="center">
   <img src="assets/demo/agent-debug-memory.gif" alt="Agent 遇到 Android 节点点击故障，查询 Noosphere，获得第 35 号已验证种子记忆，应用修复并通过回归测试" width="900">
 </div>
 
 这段 20 秒演示严格来自真实的[第 35 号工程记录](https://github.com/JinNing6/Noosphere/issues/35)。
-它展示的是尚未达到独立复现等级的**已验证 Seed Memory**。注册表同时已有 13 个
-基础实时 Skills，并明确标记为 `maintainer-validated`（维护者验证）。
+它展示的是尚未达到独立复现等级的**已验证 Seed Memory**。注册表同时已有 14 个
+实时 Skills，并明确标记为 `maintainer-validated`（维护者验证）。
 
 | 检查真实系统 | 路径 |
 |---|---|
 | 不可变 Skill 注册表 | [`shared_skills/registry.json`](shared_skills/registry.json) |
-| 13 个实时工程 Skills | [目录](docs/live-skills.md) · [当前版本镜像](shared_skills/active/) |
+| 14 个实时工程 Skills | [目录](docs/live-skills.md) · [当前版本镜像](shared_skills/active/) |
 | 不可变版本 | [`shared_skills/releases/<version>/<name>/SKILL.md`](shared_skills/releases/) |
 | 首批真实证据 | [#35](https://github.com/JinNing6/Noosphere/issues/35)、[#36](https://github.com/JinNing6/Noosphere/issues/36)、[#37](https://github.com/JinNing6/Noosphere/issues/37) |
 | 供应链协议 | [`SKILLS_PROTOCOL.md`](SKILLS_PROTOCOL.md) |
 
-**下一次贡献：**运行上面的验证命令，并将生成结果提交到专用
-[Skill 验证表单](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml)。
+**下一次贡献：**运行上面的验证命令，打开自动生成的预填链接，审核证据并提交一次独立结果。
 其他已验证工程经验仍可使用通用[记忆贡献表单](https://github.com/JinNing6/Noosphere/issues/new?template=consciousness-upload.yml)。
 **已经公开分享？**使用 [Share Proof 表单](https://github.com/JinNing6/Noosphere/issues/new?template=share-proof.yml)
 记录真实链接；Noosphere 不会根据 URL 虚构下载、推荐或留存数据。
@@ -84,7 +82,7 @@ uvx --from 'noosphere-mcp[semantic]' noosphere-mcp
 ```
 
 > [!IMPORTANT]
-> `v0.8.2` 将本地语义模型改为可选依赖，固定稳定的 MCP SDK 1.x 边界，并要求每次公开发布都在干净安装环境完成真实匿名 `initialize + tools/list` 握手，因此默认运行时可被 Glama 等目录快速扫描。首个零配置独立验证夹具、统一实时注册表和匿名只读查询均保留：匿名模式读取仓库内的规范公共索引；认证模式继续
+> `v0.8.3` 发布首个不可变 Living Skill，把验证结果变成零 Token 的预填 GitHub 提交，并由 Windows、Linux、macOS CI 强制执行同一条 60 秒门禁；公开发布验证器还会从精确 PyPI 安装中执行该命令。默认 MCP 运行时继续保持轻量、可扫描和匿名只读：匿名模式读取仓库内的规范公共索引；认证模式继续
 > 查询更新的 Issues + 永久文件。需要本地多语言向量排序时安装 `semantic` extra，否则自动降级为 BM25。所有写操作始终要求 GitHub 身份认证。
 
 ## 记忆如何进化成 Skill
@@ -94,9 +92,9 @@ uvx --from 'noosphere-mcp[semantic]' noosphere-mcp
      -> 不可变 SKILL.md -> 摘要校验后调用 -> 结果反馈 -> 更新或审核回滚
 ```
 
-Noosphere 不会直接执行社区提示词。13 个基础 Skills 已作为不可变 `1.0.0` 版本进入
+Noosphere 不会直接执行社区提示词。14 个维护者验证的实时 Skills 已作为不可变 `1.0.0` 版本进入
 同一个实时注册表，带维护者来源和 SHA-256 校验。新的社区 Skill 或更新版本仍必须具备
-结构化根因证据、两个独立发布者、人工审核、结果反馈和回滚能力。3 个已验证 Seeds
+结构化根因证据、两个独立发布者、人工审核、结果反馈和回滚能力。2 个剩余的已验证 Seeds
 尚未跨过独立复现门禁，因此不会被宣传为社区验证版本。
 
 ## 探索网络

--- a/docs/founding-debug-memories.md
+++ b/docs/founding-debug-memories.md
@@ -1,6 +1,6 @@
 # Founding Debug Memories
 
-Last updated: 2026-07-09
+Last updated: 2026-07-17
 
 Canonical launch thread: https://github.com/JinNing6/Noosphere/issues/25
 
@@ -13,6 +13,11 @@ Stop solving the same bug twice.
 ```
 
 This document turns real Noosphere engineering failures into reusable debug memories. The strongest memories can become `skill-candidate` issues and, later, callable agent skills.
+
+Current registry projection: the public-release runtime record from Issue #37 has become
+`public-artifact-runtime-smoke-gate@1.0.0`, the first immutable Living Skill at the honest
+`maintainer-validated` trust level. The R3F and dynamic supply-chain records remain the two
+verified Seeds; Issue #37 stays here as the historical evidence behind the published Skill.
 
 Every founding memory below follows the same proof shape:
 

--- a/docs/live-skills.md
+++ b/docs/live-skills.md
@@ -1,6 +1,6 @@
 # Live Engineering Skills
 
-Noosphere publishes 13 maintainer-authored Agent Skills through one live, versioned registry. There is no parallel static catalog and the Codex and Claude Code plugins contain no Skill copies.
+Noosphere publishes 14 maintainer-validated Agent Skills through one live, versioned registry. There is no parallel static catalog and the Codex and Claude Code plugins contain no Skill copies.
 
 Every active Skill has:
 
@@ -28,9 +28,9 @@ npx skills add JinNing6/Noosphere --skill debug-async-ui
 
 MCP clients can call `list_shared_skills`, `get_shared_skill`, and `check_skill_updates`. Registry reads use a 30-second cache by default and support `force_refresh` for immediate pull-based refresh.
 
-## Validate Living Skill #001
+## Living Skill #001
 
-The first independent-validation sprint targets `public-artifact-runtime-smoke-gate`:
+`public-artifact-runtime-smoke-gate@1.0.0` is the first public Living Skill built around a complete real incident, deterministic reproduction, immutable digest, and explicit `maintainer-validated` trust level:
 
 ```bash
 uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
@@ -39,12 +39,14 @@ uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
 The command builds deterministic failing and fixed Wheels, installs both through the real
 console-entry boundary in an isolated environment, and emits canonical evidence with
 artifact digests. It requires no user project, GitHub token, MCP configuration, or
-package-index account. Submit the complete generated block through the
-[dedicated validation form](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml).
+package-index account, completes under a hard 60-second gate, and prints a prefilled
+GitHub submission link. The validator only needs to review the evidence, confirm the
+declaration, and submit.
 
-One submission remains a Seed-level evidence record. The existing supply-chain gate still
-requires two independent GitHub publishers with claim-level agreement and shared public
-verification before it can create a reviewable Skill Candidate.
+The active release remains honestly labeled `maintainer-validated`. External submissions
+do not mutate it directly. Two independent GitHub publishers with claim-level agreement
+and shared public verification are still required before automation creates a reviewable
+next-version Candidate.
 
 ## Catalog
 
@@ -60,6 +62,7 @@ verification before it can create a reviewable Skill Candidate.
 | Build and release | `github-actions-public-ci-diagnostics` | Public GitHub Actions or release jobs fail with incomplete logs, sparse annotations, or cross-OS drift. |
 | Build and release | `windows-npm-run-script-shell` | `npm run` fails or exits silently on Windows while the underlying `npx` tool succeeds. |
 | Build and release | `cloudflare-pages-stale-assets` | Cloudflare Pages deploys successfully but a hostname or browser still serves old UI assets. |
+| Build and release | `public-artifact-runtime-smoke-gate` | Source tests pass but the exact installed package, CLI, MCP server, or plugin may fail at runtime. |
 | Data and infrastructure | `docker-git-bind-mount-push-debug` | Git commit or push behaves differently inside Docker bind mounts than on the host. |
 | Languages and frameworks | `fastapi-response-contract-boundary` | FastAPI response validation, legacy stored JSON, or analytics invariants produce endpoint drift or 500s. |
 | Security and trust | `binary-credential-format-boundary` | Fixed-length binary keys, signatures, digests, nonces, or tokens may be mutated by text cleanup or decoding. |

--- a/docs/project-memory-snapshot.md
+++ b/docs/project-memory-snapshot.md
@@ -1,6 +1,15 @@
 # Noosphere Project Memory Snapshot
 
-Last verified: 2026-07-16 (Asia/Shanghai)
+Last verified: 2026-07-17 (Asia/Shanghai)
+
+## Living Skill #001 Release Candidate
+
+- Branch `codex/validator-60s` promotes `public-artifact-runtime-smoke-gate@1.0.0` from historical Seed evidence into the first immutable Living Skill. Registry revision 2 now contains 14 active Skills and the generated tree contains 2 remaining verified Seeds; Seed #37 is projected through the published release evidence instead of appearing twice.
+- The release is explicitly `maintainer-validated`, with one publisher, zero independent reproductions, source Issue #37, a public deterministic fixture, immutable artifact SHA-256 `09c9b9ec1925a2d624bf6f8efb2a92ce0bc41e1c2a4b64628b4d389c043836a1`, and byte size 5,086. No external or community validation is claimed.
+- `noosphere-validate public-artifact-runtime-smoke-gate` now generates a prefilled GitHub Issue Form link containing the canonical evidence payload. The user only reviews the evidence, checks the independent-validation declaration, and submits; no token, project, MCP configuration, package-index account, or manual JSON transfer is required.
+- PR CI adds a five-minute Windows, Linux, and macOS matrix that executes the real installed command with optional GitHub credentials removed and rejects a failed run, a duration of 60 seconds or more, or a missing prefilled evidence payload. The PyPI post-publish verifier now runs the same validation command from the exact public installation in addition to the anonymous MCP `initialize + tools/list` handshake.
+- The release candidate is version `0.8.3`. A clean no-dependency install of the built Wheel executed the installed `noosphere-validate.exe` on Windows, passed in 34.45 seconds, and produced a 2,710-character prefilled URL. The complete SDK suite passed 208 tests; 28 repository tests, 93 Node supply-chain tests, registry and migration checks, focused Ruff checks, frontend lint, production build, and Skill Tree checks also passed.
+- This state is local until the branch is merged and GitHub Release `v0.8.3` completes Trusted Publishing. External validation is no longer a launch prerequisite: after public release, the operating plan is to apply the Skill to ten real external release failures, invite affected maintainers to run the 60-second command, and upgrade trust only when their authenticated evidence passes the existing gates.
 
 ## Glama MCP Directory Recovery
 

--- a/examples/reproductions/public-artifact-runtime-smoke-gate/README.md
+++ b/examples/reproductions/public-artifact-runtime-smoke-gate/README.md
@@ -2,7 +2,7 @@
 
 This deterministic fixture validates one release boundary: source code can run while the exact packaged artifact is broken.
 
-Run the complete reproduction and receive submission-ready evidence:
+Run the complete reproduction and receive a prefilled evidence submission link:
 
 ```bash
 uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
@@ -19,7 +19,7 @@ The command requires Python 3.10+ and `uv`. It does not require a validator-owne
 5. A deterministic fixed Wheel is force-installed into the same isolated environment.
 6. The real entry point succeeds and the installed distribution reports the exact fixed version.
 
-The generated Markdown contains artifact SHA-256 digests, environment details, observed exit codes, the canonical test command, and public sources. Paste the complete marked block into the [Skill validation form](https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml).
+The generated Markdown contains artifact SHA-256 digests, environment details, observed exit codes, the canonical test command, and public sources. Open its prefilled GitHub link, review the evidence, confirm the independent-validation declaration, and submit. No manual JSON transfer is required.
 
 Submission does not publish a Skill directly. Existing repository automation binds authorship to the GitHub Issue author, moderates the structured evidence, compares independent claims, and creates a review-gated Candidate only after the supply-chain requirements are met.
 

--- a/frontend/scripts/build_skill_tree_index.mjs
+++ b/frontend/scripts/build_skill_tree_index.mjs
@@ -79,7 +79,16 @@ validateRegistry(registry);
 
 const verifiedSeeds = await readVerifiedSeeds();
 const publishedNames = new Set(registry.skills.map((skill) => skill.name));
-const unpublishedSeeds = verifiedSeeds.filter((seed) => !publishedNames.has(seed.name));
+const publishedIssueEvidence = new Set(
+  registry.skills.flatMap((skill) => skill.releases || [])
+    .flatMap((release) => release.evidence || [])
+    .map((value) => String(value).match(/github\.com\/JinNing6\/Noosphere\/issues\/(\d+)/)?.[1])
+    .filter(Boolean)
+    .map(Number),
+);
+const unpublishedSeeds = verifiedSeeds.filter((seed) => (
+  !publishedNames.has(seed.name) && !publishedIssueEvidence.has(seed.source_issue)
+));
 
 for (const [kind, records] of [['published', registry.skills], ['seed', unpublishedSeeds]]) {
   const names = records.map((record) => record.name);

--- a/scripts/check_validation_result.py
+++ b/scripts/check_validation_result.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+"""Check the portable contract emitted by noosphere-validate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+
+def check_validation_result(path: Path) -> dict:
+    result = json.loads(path.read_text(encoding="utf-8"))
+    if result.get("passed") is not True:
+        raise RuntimeError("Validation result did not pass")
+
+    duration = float(result.get("duration_seconds", 0))
+    if not 0 < duration < 60:
+        raise RuntimeError(
+            f"Validation duration must be below 60 seconds, got {duration}"
+        )
+
+    submission_url = str(result.get("submission_url", ""))
+    parsed = urlsplit(submission_url)
+    query = parse_qs(parsed.query)
+    if parsed.scheme != "https" or parsed.netloc != "github.com":
+        raise RuntimeError("Validation submission URL must use GitHub HTTPS")
+    if query.get("template") != ["validate-skill.yml"]:
+        raise RuntimeError("Validation submission URL targets the wrong Issue Form")
+    evidence = query.get("generated_validation_evidence", [""])[0]
+    if not all(
+        marker in evidence
+        for marker in ["CONSCIOUSNESS_PAYLOAD_START", "CONSCIOUSNESS_PAYLOAD_END"]
+    ):
+        raise RuntimeError("Validation submission URL lacks canonical evidence markers")
+    if len(submission_url) >= 8000:
+        raise RuntimeError(
+            "Validation submission URL exceeds the tested length boundary"
+        )
+
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result", type=Path)
+    args = parser.parse_args(argv)
+    result = check_validation_result(args.result)
+    print(
+        f"Validated in {float(result['duration_seconds']):.2f}s with a prefilled evidence link"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_validation_result.py
+++ b/scripts/test_check_validation_result.py
@@ -1,0 +1,78 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from urllib.parse import urlencode
+
+from scripts.check_validation_result import check_validation_result
+
+
+def _submission_url() -> str:
+    evidence = "\n".join(
+        [
+            "<!-- CONSCIOUSNESS_PAYLOAD_START -->",
+            "```json",
+            '{"passed":true}',
+            "```",
+            "<!-- CONSCIOUSNESS_PAYLOAD_END -->",
+        ]
+    )
+    return "https://github.com/JinNing6/Noosphere/issues/new?" + urlencode(
+        {
+            "template": "validate-skill.yml",
+            "generated_validation_evidence": evidence,
+        }
+    )
+
+
+class CheckValidationResultTests(unittest.TestCase):
+    def _write(self, payload: dict) -> Path:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "validation-result.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_accepts_a_fast_pass_with_prefilled_canonical_evidence(self):
+        path = self._write(
+            {
+                "passed": True,
+                "duration_seconds": 10.66,
+                "submission_url": _submission_url(),
+            }
+        )
+
+        result = check_validation_result(path)
+
+        self.assertEqual(result["duration_seconds"], 10.66)
+
+    def test_rejects_an_over_budget_result(self):
+        path = self._write(
+            {
+                "passed": True,
+                "duration_seconds": 60,
+                "submission_url": _submission_url(),
+            }
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "below 60 seconds"):
+            check_validation_result(path)
+
+    def test_rejects_a_link_without_canonical_evidence(self):
+        path = self._write(
+            {
+                "passed": True,
+                "duration_seconds": 10,
+                "submission_url": (
+                    "https://github.com/JinNing6/Noosphere/issues/new?"
+                    "template=validate-skill.yml"
+                ),
+            }
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "canonical evidence markers"):
+            check_validation_result(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_launch_surface.py
+++ b/scripts/test_launch_surface.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-QUERY_COMMAND = 'uvx --from noosphere-mcp noosphere-query'
+QUERY_COMMAND = "uvx --from noosphere-mcp noosphere-query"
 
 
 class LaunchSurfaceTests(unittest.TestCase):
@@ -14,10 +14,11 @@ class LaunchSurfaceTests(unittest.TestCase):
         )
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertEqual(len(registry["skills"]), 13)
-        self.assertIn("Live_Skills-13", readme)
+        self.assertEqual(len(registry["skills"]), 14)
+        self.assertIn("Live_Skills-14", readme)
         self.assertIn("docs/live-skills.md", readme)
-        self.assertIn("foundational Live Skills", readme)
+        self.assertIn("maintainer-validated Live Skills", readme)
+        self.assertIn("public-artifact-runtime-smoke-gate", readme)
         for skill in registry["skills"]:
             release = next(
                 item
@@ -34,7 +35,10 @@ class LaunchSurfaceTests(unittest.TestCase):
             self.assertIn(QUERY_COMMAND, first_screen)
             self.assertIn("assets/demo/agent-debug-memory.gif", first_screen)
             self.assertIn("shared_skills/active/", first_screen)
-            self.assertLess(readme.index(QUERY_COMMAND), readme.index("assets/splash_cinematic.webp"))
+            self.assertLess(
+                readme.index(QUERY_COMMAND),
+                readme.index("assets/splash_cinematic.webp"),
+            )
 
     def test_demo_assets_and_reproducible_source_exist(self):
         gif = REPO_ROOT / "assets" / "demo" / "agent-debug-memory.gif"
@@ -56,12 +60,17 @@ class LaunchSurfaceTests(unittest.TestCase):
 
         self.assertIn("COPY sdk/pyproject.toml ./sdk/pyproject.toml", dockerfile)
         self.assertIn("COPY sdk/noosphere ./sdk/noosphere", dockerfile)
-        self.assertIn("python -m pip install --disable-pip-version-check --no-cache-dir ./sdk", dockerfile)
+        self.assertIn(
+            "python -m pip install --disable-pip-version-check --no-cache-dir ./sdk",
+            dockerfile,
+        )
         self.assertIn("USER noosphere", dockerfile)
         self.assertIn('CMD ["noosphere-mcp"]', dockerfile)
         self.assertIn("!sdk/noosphere/**", dockerignore)
         self.assertNotIn("required:\n      - githubToken", smithery)
-        self.assertIn("config.githubToken ? { GITHUB_TOKEN: config.githubToken } : {}", smithery)
+        self.assertIn(
+            "config.githubToken ? { GITHUB_TOKEN: config.githubToken } : {}", smithery
+        )
         for manifest in registry_manifests:
             environment = {
                 item["name"]: item

--- a/scripts/test_verify_pypi_release.py
+++ b/scripts/test_verify_pypi_release.py
@@ -14,8 +14,10 @@ from scripts.verify_pypi_release import (
     install_release_to_target,
     parse_mcp_probe_output,
     probe_installed_mcp_runtime,
+    probe_installed_validation_runtime,
     probe_mcp_subprocess,
     runtime_console_command,
+    runtime_validation_command,
     validate_release_json,
     verify_pypi_release,
     wait_for_installable_release,
@@ -125,6 +127,18 @@ class VerifyPypiReleaseTests(unittest.TestCase):
             self.assertEqual(
                 runtime_console_command(runtime_dir),
                 runtime_dir / "bin" / "noosphere-mcp",
+            )
+
+        with patch("scripts.verify_pypi_release.os.name", "nt"):
+            self.assertEqual(
+                runtime_validation_command(runtime_dir),
+                runtime_dir / "Scripts" / "noosphere-validate.exe",
+            )
+
+        with patch("scripts.verify_pypi_release.os.name", "posix"):
+            self.assertEqual(
+                runtime_validation_command(runtime_dir),
+                runtime_dir / "bin" / "noosphere-validate",
             )
 
     def test_mcp_probe_input_initializes_before_listing_tools(self):
@@ -289,6 +303,74 @@ print(json.dumps({
         self.assertEqual(kwargs["timeout_seconds"], 30)
         self.assertEqual(result["runtime_tool_count"], 45)
 
+    def test_probe_installed_validation_enforces_anonymous_60_second_contract(self):
+        payload = {
+            "passed": True,
+            "duration_seconds": 7.25,
+            "submission_url": (
+                "https://github.com/JinNing6/Noosphere/issues/new?"
+                "template=validate-skill.yml&generated_validation_evidence=payload"
+            ),
+        }
+        completed = subprocess.CompletedProcess(
+            args=["noosphere-validate"],
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_dir = Path(tmp)
+            command = runtime_validation_command(runtime_dir)
+            command.parent.mkdir(parents=True)
+            command.touch()
+            with (
+                patch(
+                    "scripts.verify_pypi_release.subprocess.run",
+                    return_value=completed,
+                ) as run,
+                patch.dict(
+                    "scripts.verify_pypi_release.os.environ",
+                    {"GITHUB_TOKEN": "secret", "GH_TOKEN": "secret", "PATH": "test"},
+                    clear=True,
+                ),
+            ):
+                result = probe_installed_validation_runtime(runtime_dir)
+
+        kwargs = run.call_args.kwargs
+        self.assertNotIn("GITHUB_TOKEN", kwargs["env"])
+        self.assertNotIn("GH_TOKEN", kwargs["env"])
+        self.assertEqual(kwargs["timeout"], 65.0)
+        self.assertEqual(result["validation_seconds"], 7.25)
+
+    def test_probe_installed_validation_rejects_an_over_budget_result(self):
+        payload = {
+            "passed": True,
+            "duration_seconds": 60.01,
+            "submission_url": (
+                "https://github.com/JinNing6/Noosphere/issues/new?"
+                "template=validate-skill.yml&generated_validation_evidence=payload"
+            ),
+        }
+        completed = subprocess.CompletedProcess(
+            args=["noosphere-validate"],
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_dir = Path(tmp)
+            command = runtime_validation_command(runtime_dir)
+            command.parent.mkdir(parents=True)
+            command.touch()
+            with patch(
+                "scripts.verify_pypi_release.subprocess.run",
+                return_value=completed,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "exceeded 60 seconds"):
+                    probe_installed_validation_runtime(runtime_dir)
+
     def test_wait_for_pypi_project_latest_requires_latest_version(self):
         stale_json = {
             "info": {"version": "0.6.4"},
@@ -353,6 +435,10 @@ print(json.dumps({
             "runtime_tool_count": 40,
             "runtime_seconds": 1.5,
         }
+        validation = {
+            "validation_seconds": 7.25,
+            "validation_submission_url": "https://github.com/prefilled",
+        }
 
         with (
             patch(
@@ -377,6 +463,10 @@ print(json.dumps({
                 "scripts.verify_pypi_release.probe_installed_mcp_runtime",
                 return_value=runtime,
             ) as probe_runtime,
+            patch(
+                "scripts.verify_pypi_release.probe_installed_validation_runtime",
+                return_value=validation,
+            ) as probe_validation,
         ):
             result = verify_pypi_release(
                 "noosphere-mcp",
@@ -392,9 +482,11 @@ print(json.dumps({
         inspect.assert_called_once()
         install_runtime.assert_called_once()
         probe_runtime.assert_called_once()
+        probe_validation.assert_called_once()
         self.assertEqual(result["version"], "0.6.8")
         self.assertEqual(result["tool_count"], 40)
         self.assertEqual(result["runtime_tool_count"], 40)
+        self.assertEqual(result["validation_seconds"], 7.25)
         self.assertEqual(result["latest_files"], result["files"])
 
 

--- a/scripts/verify_pypi_release.py
+++ b/scripts/verify_pypi_release.py
@@ -195,6 +195,12 @@ def runtime_console_command(runtime_dir: Path) -> Path:
     return runtime_dir / "bin" / "noosphere-mcp"
 
 
+def runtime_validation_command(runtime_dir: Path) -> Path:
+    if os.name == "nt":
+        return runtime_dir / "Scripts" / "noosphere-validate.exe"
+    return runtime_dir / "bin" / "noosphere-validate"
+
+
 def install_runtime_environment(
     project: str,
     version: str,
@@ -467,6 +473,64 @@ def probe_installed_mcp_runtime(
     return result
 
 
+def probe_installed_validation_runtime(
+    runtime_dir: Path,
+    *,
+    timeout_seconds: float = 65.0,
+) -> dict:
+    command = runtime_validation_command(runtime_dir)
+    if not command.is_file():
+        raise RuntimeError(
+            f"Published validation console entry point is missing: {command}"
+        )
+
+    env = os.environ.copy()
+    env.pop("GITHUB_TOKEN", None)
+    env.pop("GH_TOKEN", None)
+    completed = subprocess.run(
+        [
+            str(command),
+            "public-artifact-runtime-smoke-gate",
+            "--format",
+            "json",
+        ],
+        cwd=runtime_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout_seconds,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Published validation command failed: "
+            + (completed.stderr.strip() or completed.stdout.strip())[-2000:]
+        )
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Published validation command did not return JSON") from exc
+    duration = float(result.get("duration_seconds", 0))
+    submission_url = str(result.get("submission_url", ""))
+    if result.get("passed") is not True or not 0 < duration < 60:
+        raise RuntimeError(
+            f"Published validation contract failed or exceeded 60 seconds: {result}"
+        )
+    if (
+        "template=validate-skill.yml" not in submission_url
+        or "generated_validation_evidence=" not in submission_url
+    ):
+        raise RuntimeError(
+            "Published validation command lacks a prefilled evidence URL"
+        )
+    return {
+        "validation_seconds": duration,
+        "validation_submission_url": submission_url,
+    }
+
+
 def inspect_installed_release(
     target_dir: Path,
     expected_version: str,
@@ -587,6 +651,7 @@ def verify_pypi_release(
             expected_version=version,
             expected_tool_count=expected_tool_count,
         )
+        validation = probe_installed_validation_runtime(runtime_dir)
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
 
@@ -597,6 +662,7 @@ def verify_pypi_release(
         "latest_files": latest_filenames,
         **installed,
         **runtime,
+        **validation,
     }
 
 
@@ -621,7 +687,7 @@ def main(argv: list[str] | None = None) -> int:
         f"Verified {result['project']}=={result['version']}: "
         f"{result['runtime_tool_count']} MCP tools via initialize + tools/list in "
         f"{result['runtime_seconds']:.3f}s; growth ledger tools, noosphere-query and "
-        "noosphere-validate present."
+        f"the token-free validation path passed in {result['validation_seconds']:.2f}s."
     )
     return 0
 

--- a/sdk/noosphere/__init__.py
+++ b/sdk/noosphere/__init__.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
     from noosphere.client import Noosphere
 
 __all__ = ["Noosphere"]
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 
 def __getattr__(name: str):

--- a/sdk/noosphere/validation_cli.py
+++ b/sdk/noosphere/validation_cli.py
@@ -12,9 +12,9 @@ from pathlib import Path
 
 from noosphere import __version__
 from noosphere.validation_kits.public_artifact_runtime_smoke_gate import (
-    FORM_URL,
     SKILL_NAME,
     ValidationKitError,
+    build_submission_url,
     render_evidence_markdown,
     run_validation,
 )
@@ -60,7 +60,7 @@ def configure_console_output() -> None:
 def _render_json(result, workdir: Path | None) -> str:
     data = json.loads(result.as_json())
     data["workdir"] = str(workdir) if workdir else None
-    data["submission_url"] = FORM_URL
+    data["submission_url"] = build_submission_url(result)
     return json.dumps(data, ensure_ascii=False, indent=2)
 
 
@@ -89,7 +89,7 @@ def main(argv: list[str] | None = None) -> int:
         if retained_workdir:
             print(f"Validation workdir retained at {retained_workdir}")
         if result.passed and args.open_form:
-            webbrowser.open(FORM_URL, new=2)
+            webbrowser.open(build_submission_url(result), new=2)
         return 0 if result.passed else 1
     except (OSError, subprocess.SubprocessError, ValidationKitError) as exc:
         print(f"Validation harness failed: {exc}", file=sys.stderr)

--- a/sdk/noosphere/validation_kits/public_artifact_runtime_smoke_gate.py
+++ b/sdk/noosphere/validation_kits/public_artifact_runtime_smoke_gate.py
@@ -17,10 +17,12 @@ import zipfile
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from urllib.parse import urlencode
 
 SKILL_NAME = "public-artifact-runtime-smoke-gate"
 VALIDATION_COMMAND = "uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate"
 FORM_URL = "https://github.com/JinNing6/Noosphere/issues/new?template=validate-skill.yml"
+ISSUE_NEW_URL = "https://github.com/JinNing6/Noosphere/issues/new"
 FIXTURE_URL = (
     "https://github.com/JinNing6/Noosphere/tree/main/examples/reproductions/public-artifact-runtime-smoke-gate"
 )
@@ -360,8 +362,40 @@ def build_evidence_payload(result: ValidationResult) -> dict:
     }
 
 
+def _evidence_block(payload: dict, *, pretty: bool) -> str:
+    serialized = json.dumps(
+        payload,
+        ensure_ascii=False,
+        indent=2 if pretty else None,
+        separators=None if pretty else (",", ":"),
+    )
+    return "\n".join(
+        [
+            PAYLOAD_START,
+            "```json",
+            serialized,
+            "```",
+            PAYLOAD_END,
+        ]
+    )
+
+
+def build_submission_url(result: ValidationResult) -> str:
+    """Build a token-free GitHub Issue Form URL with canonical evidence prefilled."""
+    payload = build_evidence_payload(result)
+    query = urlencode(
+        {
+            "template": "validate-skill.yml",
+            "title": f"Skill validation: {SKILL_NAME}",
+            "generated_validation_evidence": _evidence_block(payload, pretty=False),
+        }
+    )
+    return f"{ISSUE_NEW_URL}?{query}"
+
+
 def render_evidence_markdown(result: ValidationResult) -> str:
     payload = build_evidence_payload(result)
+    submission_url = build_submission_url(result)
     return "\n".join(
         [
             "# Noosphere Skill validation",
@@ -373,15 +407,12 @@ def render_evidence_markdown(result: ValidationResult) -> str:
             f"- Failing artifact: `{result.failing_artifact_sha256}`",
             f"- Fixed artifact: `{result.fixed_artifact_sha256}`",
             "",
-            "Paste the complete block below into the **Generated validation evidence** field:",
+            "The submission link below already contains this canonical evidence block:",
             "",
-            PAYLOAD_START,
-            "```json",
-            json.dumps(payload, ensure_ascii=False, indent=2),
-            "```",
-            PAYLOAD_END,
+            _evidence_block(payload, pretty=True),
             "",
-            f"Submit: {FORM_URL}",
+            "Open the prefilled form, review the evidence, confirm the declaration, and submit:",
+            f"{submission_url}",
             "",
             "The repository workflow binds authorship to the submitting GitHub account and "
             "review-gates the evidence before it can affect a published Skill.",

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "noosphere-mcp"
-version = "0.8.2"
+version = "0.8.3"
 description = "🧠 Noosphere — 集体意识网络 MCP Server，直连 GitHub 意识仓库"
 readme = "../README.md"
 requires-python = ">=3.10"

--- a/sdk/server.json
+++ b/sdk/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "JinNing6/Noosphere"
   },
-  "version": "0.8.2",
+  "version": "0.8.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "noosphere-mcp",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/sdk/tests/test_validation_cli.py
+++ b/sdk/tests/test_validation_cli.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import zipfile
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
@@ -16,6 +17,7 @@ from noosphere.validation_kits.public_artifact_runtime_smoke_gate import (
     VALIDATION_COMMAND,
     build_evidence_payload,
     build_fixture_wheel,
+    build_submission_url,
     render_evidence_markdown,
     run_validation,
 )
@@ -55,6 +57,7 @@ def test_validation_reproduces_the_artifact_failure_and_verifies_the_fix(complet
     assert f"{PACKAGE_NAME}.__main__" in result.observed_failure
     assert '"status": "runtime-ok"' in result.observed_success
     assert "<validation-workdir>" in result.observed_failure
+    assert result.duration_seconds < 60
 
 
 def test_generated_evidence_is_canonical_and_submission_ready(completed_validation):
@@ -71,6 +74,22 @@ def test_generated_evidence_is_canonical_and_submission_ready(completed_validati
     assert FORM_URL in markdown
 
 
+def test_submission_url_prefills_canonical_evidence_without_credentials(completed_validation):
+    submission_url = build_submission_url(completed_validation)
+    parsed_url = urlsplit(submission_url)
+    query = parse_qs(parsed_url.query)
+    marker_body = query["generated_validation_evidence"][0].split(PAYLOAD_START, 1)[1].split(PAYLOAD_END, 1)[0].strip()
+    parsed_payload = json.loads(marker_body.removeprefix("```json").removesuffix("```").strip())
+
+    assert parsed_url.scheme == "https"
+    assert parsed_url.netloc == "github.com"
+    assert query["template"] == ["validate-skill.yml"]
+    assert query["title"] == [f"Skill validation: {SKILL_NAME}"]
+    assert parsed_payload == build_evidence_payload(completed_validation)
+    assert len(submission_url) < 8000
+    assert "token=" not in submission_url.lower()
+
+
 def test_cli_has_one_explicit_kit_and_writes_generated_evidence(tmp_path, completed_validation):
     args = build_parser().parse_args([SKILL_NAME, "--format", "markdown"])
     output = tmp_path / "evidence.md"
@@ -81,3 +100,15 @@ def test_cli_has_one_explicit_kit_and_writes_generated_evidence(tmp_path, comple
 
     assert exit_code == 0
     assert PAYLOAD_START in output.read_text(encoding="utf-8")
+
+
+def test_cli_opens_the_prefilled_submission_url(completed_validation):
+    expected_url = build_submission_url(completed_validation)
+    with (
+        patch("noosphere.validation_cli.run_validation", return_value=completed_validation),
+        patch("noosphere.validation_cli.webbrowser.open") as open_browser,
+    ):
+        exit_code = main([SKILL_NAME, "--format", "json", "--open-form"])
+
+    assert exit_code == 0
+    open_browser.assert_called_once_with(expected_url, new=2)

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "JinNing6/Noosphere"
   },
-  "version": "0.8.2",
+  "version": "0.8.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "noosphere-mcp",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/shared_skills/active/public-artifact-runtime-smoke-gate/SKILL.md
+++ b/shared_skills/active/public-artifact-runtime-smoke-gate/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: public-artifact-runtime-smoke-gate
+description: Verify Python packages, CLIs, MCP servers, and Agent plugins through the exact installed artifact and real runtime contract. Use when source tests pass but a published release may omit modules, expose broken entry points, depend on local paths, fail without optional credentials, or behave differently after public installation.
+---
+
+# Public Artifact Runtime Smoke Gate
+
+Prove the artifact users install, not the source tree that produced it. Treat source tests, built artifacts, public-index resolution, installed entry points, and runtime protocol behavior as separate evidence layers.
+
+## Required Gate
+
+1. Identify the intended immutable release commit, version, and public registry.
+2. Wait for that exact version to appear in the public registry with bounded retries.
+3. Create a clean environment outside the repository and disable local project discovery.
+4. Install the exact public version with caches disabled where the package manager permits.
+5. Read the installed distribution's version from its own metadata.
+6. Launch the installed console entry point as a subprocess. Do not substitute `python -m` against the checkout.
+7. Remove optional credentials from the child environment and verify the documented anonymous or degraded behavior.
+8. Exercise a representative runtime contract. For MCP stdio, send `initialize`, wait for its response, send `notifications/initialized`, then request `tools/list` before closing stdin.
+9. Assert stable product-owned fields, required capabilities, exit status, and bounded runtime.
+10. Record the exact version, command, environment, artifact digest, observed failure, observed success, and verification result.
+
+## One-Minute Reproduction
+
+Use Noosphere's deterministic fixture to reproduce the source-versus-artifact failure and verify the repair without a project or token:
+
+```bash
+uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
+```
+
+The command must finish in under 60 seconds on the supported CI runners. It builds byte-deterministic failing and fixed Wheels, installs them in an isolated environment without external package resolution, invokes the real installed entry point, verifies the exact distribution version, and emits a prefilled evidence submission link.
+
+## Isolation Rules
+
+- Never use an editable install, repository import path, local Wheel, or unversioned `latest` install as final public-release evidence.
+- Run from a directory that cannot import the checkout accidentally.
+- Strip optional secrets such as `GITHUB_TOKEN` and `GH_TOKEN`; never print credential values.
+- Verify package metadata independently from framework-owned protocol metadata.
+- Reject non-protocol data on MCP stdout because logs corrupt stdio framing.
+- Drain stdout and stderr concurrently and terminate the process tree on timeout.
+- Keep heavyweight models, browser stacks, GPU runtimes, and scientific packages behind explicit extras when they are not required for cold discovery.
+
+## Failure Classification
+
+| Observation | Classify first as | Inspect |
+|---|---|---|
+| Exact version cannot be resolved | Registry propagation | Registry JSON, index selection, retry window |
+| Source runs but installed entry point fails | Artifact drift | Wheel contents, package data, entry-point target |
+| Process exits before protocol initialization | Runtime startup | Dependencies, environment, auth preflight, transport |
+| Initialize succeeds but discovery fails | Lifecycle or contract | Message ordering, stdin lifetime, stdout purity |
+| Anonymous run fails while authenticated run works | Auth boundary | Required versus optional credentials, degraded mode |
+| Warm retry passes after cold failure | Cold-start boundary | Dependency weight, downloads, caches, scanner timeout |
+| Runtime succeeds but assertion references the wrong field | Harness contract | Production code and tests, field ownership, exit codes |
+
+Do not change production code when the smoke harness guessed the contract incorrectly. Correct the harness from production-owned evidence, then rerun the complete gate.
+
+## Completion Standard
+
+The release is verified only when all of these are true:
+
+- the public registry exposes the exact intended version;
+- an isolated environment reports that installed distribution version;
+- the installed entry point starts without source-tree assistance;
+- the representative runtime or protocol contract completes within its deadline;
+- missing optional credentials produce the documented behavior;
+- required capabilities and product-owned metadata match the release contract;
+- the commands, digests, exit statuses, and machine-readable result are retained;
+- CI and a clean public-artifact run both pass.
+
+## Trust Boundary
+
+This `1.0.0` release is **maintainer-validated**. That means its immutable artifact, deterministic fixture, test command, digest, and review state are public. It does not claim independent reproduction until evidence arrives from the required independent GitHub publishers and passes maintainer review.

--- a/shared_skills/registry.json
+++ b/shared_skills/registry.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
-  "revision": 1,
-  "generated_at": "2026-07-15T05:57:32.045Z",
+  "revision": 2,
+  "generated_at": "2026-07-17T06:33:24.000Z",
   "skills": [
     {
       "id": "noosphere:agent-debug-memory",
@@ -418,6 +418,52 @@
             "path": "shared_skills/releases/1.0.0/github-actions-public-ci-diagnostics/SKILL.md",
             "sha256": "201e097abe1756d787f6e5f370e9a5969f9485980bb64c6d70dd4a77682bb9c7",
             "size_bytes": 4075
+          },
+          "withdrawal": null
+        }
+      ]
+    },
+    {
+      "id": "noosphere:public-artifact-runtime-smoke-gate",
+      "name": "public-artifact-runtime-smoke-gate",
+      "description": "Verify Python packages, CLIs, MCP servers, and Agent plugins through the exact installed artifact and real runtime contract. Use when source tests pass but a published release may omit modules, expose broken entry points, depend on local paths, fail without optional credentials, or behave differently after public installation.",
+      "domain": "build-release",
+      "tags": [
+        "build-release",
+        "artifact-runtime",
+        "live-skill"
+      ],
+      "originators": [
+        "JinNing6"
+      ],
+      "latest": "1.0.0",
+      "releases": [
+        {
+          "version": "1.0.0",
+          "summary": "Maintainer-validated public-artifact runtime gate with a deterministic, token-free, sub-60-second reproduction path.",
+          "published_at": "2026-07-17T06:33:24.000Z",
+          "status": "active",
+          "reviewer": "JinNing6",
+          "source_count": 1,
+          "publisher_count": 1,
+          "evidence": [
+            "https://github.com/JinNing6/Noosphere/issues/37",
+            "https://github.com/JinNing6/Noosphere/tree/main/examples/reproductions/public-artifact-runtime-smoke-gate"
+          ],
+          "verification": {
+            "level": "maintainer-validated",
+            "independent_reproductions": 0,
+            "verified_outcomes": 0
+          },
+          "provenance": {
+            "kind": "maintainer-authored",
+            "repository": "JinNing6/Noosphere",
+            "author": "JinNing6"
+          },
+          "artifact": {
+            "path": "shared_skills/releases/1.0.0/public-artifact-runtime-smoke-gate/SKILL.md",
+            "sha256": "09c9b9ec1925a2d624bf6f8efb2a92ce0bc41e1c2a4b64628b4d389c043836a1",
+            "size_bytes": 5086
           },
           "withdrawal": null
         }

--- a/shared_skills/releases/1.0.0/public-artifact-runtime-smoke-gate/SKILL.md
+++ b/shared_skills/releases/1.0.0/public-artifact-runtime-smoke-gate/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: public-artifact-runtime-smoke-gate
+description: Verify Python packages, CLIs, MCP servers, and Agent plugins through the exact installed artifact and real runtime contract. Use when source tests pass but a published release may omit modules, expose broken entry points, depend on local paths, fail without optional credentials, or behave differently after public installation.
+---
+
+# Public Artifact Runtime Smoke Gate
+
+Prove the artifact users install, not the source tree that produced it. Treat source tests, built artifacts, public-index resolution, installed entry points, and runtime protocol behavior as separate evidence layers.
+
+## Required Gate
+
+1. Identify the intended immutable release commit, version, and public registry.
+2. Wait for that exact version to appear in the public registry with bounded retries.
+3. Create a clean environment outside the repository and disable local project discovery.
+4. Install the exact public version with caches disabled where the package manager permits.
+5. Read the installed distribution's version from its own metadata.
+6. Launch the installed console entry point as a subprocess. Do not substitute `python -m` against the checkout.
+7. Remove optional credentials from the child environment and verify the documented anonymous or degraded behavior.
+8. Exercise a representative runtime contract. For MCP stdio, send `initialize`, wait for its response, send `notifications/initialized`, then request `tools/list` before closing stdin.
+9. Assert stable product-owned fields, required capabilities, exit status, and bounded runtime.
+10. Record the exact version, command, environment, artifact digest, observed failure, observed success, and verification result.
+
+## One-Minute Reproduction
+
+Use Noosphere's deterministic fixture to reproduce the source-versus-artifact failure and verify the repair without a project or token:
+
+```bash
+uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate
+```
+
+The command must finish in under 60 seconds on the supported CI runners. It builds byte-deterministic failing and fixed Wheels, installs them in an isolated environment without external package resolution, invokes the real installed entry point, verifies the exact distribution version, and emits a prefilled evidence submission link.
+
+## Isolation Rules
+
+- Never use an editable install, repository import path, local Wheel, or unversioned `latest` install as final public-release evidence.
+- Run from a directory that cannot import the checkout accidentally.
+- Strip optional secrets such as `GITHUB_TOKEN` and `GH_TOKEN`; never print credential values.
+- Verify package metadata independently from framework-owned protocol metadata.
+- Reject non-protocol data on MCP stdout because logs corrupt stdio framing.
+- Drain stdout and stderr concurrently and terminate the process tree on timeout.
+- Keep heavyweight models, browser stacks, GPU runtimes, and scientific packages behind explicit extras when they are not required for cold discovery.
+
+## Failure Classification
+
+| Observation | Classify first as | Inspect |
+|---|---|---|
+| Exact version cannot be resolved | Registry propagation | Registry JSON, index selection, retry window |
+| Source runs but installed entry point fails | Artifact drift | Wheel contents, package data, entry-point target |
+| Process exits before protocol initialization | Runtime startup | Dependencies, environment, auth preflight, transport |
+| Initialize succeeds but discovery fails | Lifecycle or contract | Message ordering, stdin lifetime, stdout purity |
+| Anonymous run fails while authenticated run works | Auth boundary | Required versus optional credentials, degraded mode |
+| Warm retry passes after cold failure | Cold-start boundary | Dependency weight, downloads, caches, scanner timeout |
+| Runtime succeeds but assertion references the wrong field | Harness contract | Production code and tests, field ownership, exit codes |
+
+Do not change production code when the smoke harness guessed the contract incorrectly. Correct the harness from production-owned evidence, then rerun the complete gate.
+
+## Completion Standard
+
+The release is verified only when all of these are true:
+
+- the public registry exposes the exact intended version;
+- an isolated environment reports that installed distribution version;
+- the installed entry point starts without source-tree assistance;
+- the representative runtime or protocol contract completes within its deadline;
+- missing optional credentials produce the documented behavior;
+- required capabilities and product-owned metadata match the release contract;
+- the commands, digests, exit statuses, and machine-readable result are retained;
+- CI and a clean public-artifact run both pass.
+
+## Trust Boundary
+
+This `1.0.0` release is **maintainer-validated**. That means its immutable artifact, deterministic fixture, test command, digest, and review state are public. It does not claim independent reproduction until evidence arrives from the required independent GitHub publishers and passes maintainer review.


### PR DESCRIPTION
## Summary
- publish `public-artifact-runtime-smoke-gate@1.0.0` as the first immutable, honestly labeled `maintainer-validated` Living Skill
- reduce validation handoff to one token-free command plus a prefilled GitHub evidence form
- enforce the sub-60-second contract on Windows, Linux, macOS and the exact installed PyPI artifact

## Verification
- `208 passed` in the complete SDK suite
- `93 passed` in the Node supply-chain suite
- repository validator, migration, launch-surface, and PyPI verifier tests pass
- registry validation and Skill Tree contract pass at `14 live / 2 seeds`
- frontend lint and production build pass
- exact `0.8.3` Wheel install ran `noosphere-validate.exe` in 34.45 seconds and generated a 2,710-character prefilled evidence URL
- `npx skills add . --list` discovers all 14 Skills

## Trust boundary
This PR does not claim external reproduction. Living Skill #001 remains `maintainer-validated` with one publisher and zero independent reproductions until authenticated external evidence passes the existing review gates.