### PR TITLE
Align launch metadata with v0.8.3

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "noosphere-marketplace",
   "interface": {
-    "displayName": "Noosphere Agent Memory"
+    "displayName": "Noosphere Live Skills"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "noosphere-agent-memory",
   "description": "Noosphere plugins for shared agent debugging memory and verified dynamic Skills.",
-  "version": "0.4.0",
+  "version": "0.8.3",
   "owner": {
     "name": "JinNing6",
     "email": "noosphere@consciousness.network"
@@ -11,7 +11,7 @@
       "name": "noosphere",
       "source": "./plugins/claude-noosphere",
       "description": "Shared debug memory and verified dynamic Skills for Claude Code agents.",
-      "version": "0.4.0",
+      "version": "0.8.3",
       "author": {
         "name": "JinNing6",
         "email": "noosphere@consciousness.network"

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Noosphere is now packaged as a GitHub-installable Codex marketplace. You do not 
 codex plugin marketplace add JinNing6/Noosphere
 ```
 
-Then restart Codex, open the plugin directory, choose **Noosphere Agent Memory**, and install **Noosphere**.
+Then restart Codex, open the plugin directory, choose **Noosphere Live Skills**, and install **Noosphere**.
 
 Public read-only consultation works without `GITHUB_TOKEN`. For uploads and higher GitHub API limits, start Codex with `GITHUB_TOKEN` available in the environment. The plugin forwards that token to the `noosphere-mcp` server and targets `JinNing6/Noosphere` by default.
 

--- a/docs/project-memory-snapshot.md
+++ b/docs/project-memory-snapshot.md
@@ -1,6 +1,15 @@
 # Noosphere Project Memory Snapshot
 
-Last verified: 2026-07-17 (Asia/Shanghai)
+Last verified: 2026-07-20 (Asia/Shanghai)
+
+## Launch Metadata Alignment
+
+- Codex and Claude Code plugin manifests, the Claude marketplace, and the public MCP package now share version `0.8.3`. Explicit Claude plugin versions are cache keys, so future plugin-visible changes must bump the manifest version instead of relying on a repository commit alone.
+- Public plugin descriptions and documentation now report the canonical registry state of 14 active Live Skills and 2 remaining verified Seeds. Repository validation derives these values from `shared_skills/registry.json` and rejects future count drift.
+- The repository marketplace display name is `Noosphere Live Skills`, aligned with the current product category rather than the legacy Agent Memory entry point.
+- The Codex plugin MCP companion file now uses the current `mcpServers` schema. The bundled plugin validator rejects the legacy `mcp_servers` spelling, and repository validation now guards this boundary.
+- GitHub repository Topics are managed as public discovery metadata. The launch set targets Agent Skills, MCP, coding Agents, debugging, shared memory, supported Agent runtimes, and developer tooling.
+- The public `noosphere-mcp==0.8.3` validation command was re-run on Windows 11 on 2026-07-20. The deterministic failure/fix boundary passed in 27.22 seconds of validation time and 29.42 seconds end to end.
 
 ## Living Skill #001 Public Release
 
@@ -59,7 +68,7 @@ Last verified: 2026-07-17 (Asia/Shanghai)
 - The default surface is a workbench, not a marketing landing page: global search, Tree and Directory views, eight deterministic engineering domains, Skill details, version history, Agent connection guidance, and structured contribution entry points are available in English and Chinese.
 - The tree index is generated only from repository truth. At verification time it contains 13 Live Skills from `shared_skills/registry.json` revision 1 and 3 verified Skill Seeds. Seed ingestion requires trusted review, Skill eligibility, complete symptom/root-cause/fix/verification evidence, and at least one test command; a Seed is excluded when a same-name Live Skill exists.
 - The original three Noosphere workflows plus ten maintainer-authored engineering playbooks now have immutable `1.0.0` releases, active mirrors, exact SHA-256 and byte-size records, provenance, reviewers, and rollback state. Their explicit trust level is `maintainer-validated`; they are usable but are not claimed as independently reproduced.
-- Codex and Claude Code plugins contain no Skill copies. Plugin and marketplace manifests are aligned at version `0.4.0`; Agents discover the same registry through MCP, while standards-compatible installers discover all 13 active mirrors under `shared_skills/active/`.
+- At the `v0.8.0` Skill Tree release, Codex and Claude Code plugins contained no Skill copies, plugin manifests were still at `0.4.0`, and standards-compatible installers discovered 13 active mirrors. The current `0.8.3` launch metadata and 14-Skill registry state are recorded in the alignment section above.
 - The SDK is prepared as `0.8.0`. Registry reads use a 30-second cache with explicit `force_refresh`, and `upload_consciousness` accepts `target_skill` so an Agent can submit evidence for an existing Skill version without crossing identity boundaries.
 - Community actions remain review-gated. Creating or updating a Skill emits the same structured `CONSCIOUSNESS_PAYLOAD` used by MCP, including `target_skill` and engineering evidence; the browser never writes directly to the immutable registry. Two independent GitHub publishers, claim-level agreement, shared executable verification, canonical evidence rehydration, and maintainer approval are mandatory for a community release.
 - The WebGL tree uses responsive node spacing and dedicated transparent hit geometry on mobile. Playwright checks at a 390 x 844 viewport selected two vertically adjacent Skill nodes independently, and the directory search for `runtime smoke` returned the single matching verified Seed without horizontal overflow.

--- a/plugins/claude-noosphere/.claude-plugin/plugin.json
+++ b/plugins/claude-noosphere/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "noosphere",
-  "version": "0.4.0",
+  "version": "0.8.3",
   "description": "Live, versioned shared Skills and debug memory for Claude Code agents.",
   "author": {
     "name": "JinNing6",

--- a/plugins/claude-noosphere/README.md
+++ b/plugins/claude-noosphere/README.md
@@ -2,7 +2,7 @@
 
 Noosphere gives Claude Code shared debug memory and review-gated dynamic Skills.
 
-The plugin connects Claude Code to one live registry containing 13 Agent Skills:
+The plugin connects Claude Code to one live registry containing 14 Agent Skills:
 
 - Noosphere MCP tools through `uvx noosphere-mcp`
 - `agent-debug-memory` for consulting shared memory before debugging

--- a/plugins/claude-noosphere/SUBMISSION.md
+++ b/plugins/claude-noosphere/SUBMISSION.md
@@ -23,7 +23,7 @@ Stop solving the same bug twice. Noosphere lets Claude Code consult and publish 
 Long description:
 
 ```text
-Noosphere turns verified debugging lessons into shared agent memory and live, review-gated Agent Skills. Claude Code can discover 13 versioned foundational Skills, verify exact digests, check updates, report execution outcomes, and upload reproducible evidence for a new version through MCP. The plugin contains the MCP connection and manual slash commands, while Skills remain in one public immutable registry.
+Noosphere turns verified debugging lessons into shared agent memory and live, review-gated Agent Skills. Claude Code can discover 14 versioned foundational Skills, verify exact digests, check updates, report execution outcomes, and upload reproducible evidence for a new version through MCP. The plugin contains the MCP connection and manual slash commands, while Skills remain in one public immutable registry.
 ```
 
 ## Review Notes

--- a/plugins/noosphere/.codex-plugin/plugin.json
+++ b/plugins/noosphere/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "noosphere",
-  "version": "0.4.0",
+  "version": "0.8.3",
   "description": "Agent Debug Memory and verified dynamic shared Skills for Codex, powered by Noosphere MCP.",
   "author": {
     "name": "JinNing6",
@@ -23,7 +23,7 @@
   "interface": {
     "displayName": "Noosphere",
     "shortDescription": "Live, versioned shared Skills for Codex agents.",
-    "longDescription": "Noosphere connects Codex to one live Skill registry. Discover 13 versioned engineering workflows, verify exact digests, retrieve reviewed updates, contribute execution evidence, and request auditable rollback without static plugin copies.",
+    "longDescription": "Noosphere connects Codex to one live Skill registry. Discover 14 versioned engineering workflows, verify exact digests, retrieve reviewed updates, contribute execution evidence, and request auditable rollback without static plugin copies.",
     "developerName": "JinNing6",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/noosphere/.mcp.json
+++ b/plugins/noosphere/.mcp.json
@@ -1,5 +1,5 @@
 {
-  "mcp_servers": {
+  "mcpServers": {
     "noosphere": {
       "command": "uvx",
       "args": [

--- a/plugins/noosphere/README.md
+++ b/plugins/noosphere/README.md
@@ -2,7 +2,7 @@
 
 Noosphere turns debugging experience into shared agent memory and review-gated dynamic Skills for Codex.
 
-The plugin connects Codex to one live registry containing 13 Agent Skills:
+The plugin connects Codex to one live registry containing 14 Agent Skills:
 
 - Noosphere MCP tools through `uvx noosphere-mcp`
 - `agent-debug-memory` for consulting shared memory before debugging
@@ -20,7 +20,7 @@ From any Codex environment:
 codex plugin marketplace add JinNing6/Noosphere
 ```
 
-Restart Codex, open the plugin directory, choose **Noosphere Agent Memory**, then install **Noosphere**.
+Restart Codex, open the plugin directory, choose **Noosphere Live Skills**, then install **Noosphere**.
 
 ## Auth
 

--- a/scripts/render-launch-demo.ps1
+++ b/scripts/render-launch-demo.ps1
@@ -38,7 +38,7 @@ drawtext=fontfile='C\:/Windows/Fonts/consola.ttf':text='PASS  intended instance 
 drawtext=fontfile='C\:/Windows/Fonts/consola.ttf':text='One verified failure became reusable memory.':x=70:y=220:fontsize=20:fontcolor=0x58d6ff:enable='between(t,16,18.7)',
 drawbox=x=42:y=414:w=876:h=92:color=0x111827:t=fill:enable='between(t,18.7,20)',
 drawtext=fontfile='C\:/Windows/Fonts/consola.ttf':text='STOP SOLVING THE SAME BUG TWICE.':x=118:y=440:fontsize=31:fontcolor=0xffffff:enable='between(t,18.7,20)',
-drawtext=fontfile='C\:/Windows/Fonts/consola.ttf':text='13 live Skills  |  3 verified seeds  |  review-gated':x=70:y=532:fontsize=17:fontcolor=0x8b949e,
+drawtext=fontfile='C\:/Windows/Fonts/consola.ttf':text='14 live Skills  |  2 verified seeds  |  review-gated':x=70:y=532:fontsize=17:fontcolor=0x8b949e,
 format=yuv420p[out]
 '@
 

--- a/scripts/test_validate_shared_skills.py
+++ b/scripts/test_validate_shared_skills.py
@@ -22,6 +22,13 @@ description: Recover a verified test failure.
 
 
 class SharedSkillValidationTests(unittest.TestCase):
+    def test_repository_launch_metadata_matches_registry_and_sdk(self):
+        root = Path(__file__).resolve().parents[1]
+
+        errors = validate_repository(root)
+
+        self.assertEqual(errors, [])
+
     def test_outcome_ledger_counts_and_independent_proof_must_match_registry(self):
         digest = "a" * 64
         registry = {
@@ -317,6 +324,26 @@ class SharedSkillValidationTests(unittest.TestCase):
         self.assertTrue(
             any("must load live Skills through MCP" in error for error in errors)
         )
+
+    def test_repository_rejects_legacy_codex_mcp_field(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            registry_path = root / "shared_skills/registry.json"
+            registry_path.parent.mkdir(parents=True)
+            registry_path.write_text(
+                json.dumps({"schema_version": "1.0", "revision": 0, "skills": []}),
+                encoding="utf-8",
+            )
+            mcp_config = root / "plugins/noosphere/.mcp.json"
+            mcp_config.parent.mkdir(parents=True)
+            mcp_config.write_text(
+                json.dumps({"mcp_servers": {"noosphere": {}}}),
+                encoding="utf-8",
+            )
+
+            errors = validate_repository(root)
+
+        self.assertTrue(any("current `mcpServers` field" in error for error in errors))
 
 
 if __name__ == "__main__":

--- a/scripts/validate_shared_skills.py
+++ b/scripts/validate_shared_skills.py
@@ -340,11 +340,79 @@ def validate_repository(root: Path) -> list[str]:
             errors.append(
                 f"Plugin manifest versions diverge: {sorted(str(value) for value in versions)}"
             )
+        sdk_init = root / "sdk" / "noosphere" / "__init__.py"
+        try:
+            sdk_init_text = sdk_init.read_text(encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"Cannot read SDK version metadata: {exc}")
+        else:
+            sdk_version_match = re.search(
+                r'^__version__\s*=\s*["\'](\d+\.\d+\.\d+)["\']',
+                sdk_init_text,
+                re.MULTILINE,
+            )
+            if not sdk_version_match:
+                errors.append("Cannot parse SDK version metadata")
+            elif versions != {sdk_version_match.group(1)}:
+                errors.append(
+                    "Plugin manifests must match the public SDK version: "
+                    f"sdk={sdk_version_match.group(1)}, "
+                    f"plugins={sorted(str(value) for value in versions)}"
+                )
+
+        active_skill_count = sum(
+            1
+            for skill in registry.get("skills", [])
+            if isinstance(skill, dict) and skill.get("latest")
+        )
+        codex_description = manifests[0].get("interface", {}).get("longDescription", "")
+        expected_description = f"Discover {active_skill_count} versioned"
+        if expected_description not in codex_description:
+            errors.append(
+                f"Codex plugin Skill count drift: expected `{expected_description}`"
+            )
+
+        count_copy = [
+            (
+                root / "plugins" / "noosphere" / "README.md",
+                f"containing {active_skill_count} Agent Skills",
+            ),
+            (
+                root / "plugins" / "claude-noosphere" / "README.md",
+                f"containing {active_skill_count} Agent Skills",
+            ),
+            (
+                root / "plugins" / "claude-noosphere" / "SUBMISSION.md",
+                f"discover {active_skill_count} versioned foundational Skills",
+            ),
+        ]
+        for path, expected in count_copy:
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError as exc:
+                errors.append(f"Cannot read plugin launch metadata {path}: {exc}")
+                continue
+            if expected not in text:
+                errors.append(
+                    f"Plugin Skill count drift in {path}: expected `{expected}`"
+                )
         for path, manifest in zip(manifest_paths[:2], manifests[:2], strict=True):
             if manifest.get("skills"):
                 errors.append(
                     f"Plugin must load live Skills through MCP, not bundle static copies: {path}"
                 )
+    codex_mcp_path = root / "plugins" / "noosphere" / ".mcp.json"
+    try:
+        codex_mcp = json.loads(codex_mcp_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f"Cannot parse Codex plugin MCP configuration: {exc}")
+    else:
+        if set(codex_mcp) != {"mcpServers"}:
+            errors.append(
+                "Codex plugin .mcp.json must contain only the current `mcpServers` field"
+            )
+        elif not isinstance(codex_mcp["mcpServers"].get("noosphere"), dict):
+            errors.append("Codex plugin .mcp.json is missing the noosphere server")
     return errors
 
 

--- a/sdk/noosphere/boot_animation.py
+++ b/sdk/noosphere/boot_animation.py
@@ -11,6 +11,8 @@ import shutil
 import sys
 import time
 
+from noosphere import __version__
+
 
 # ── ANSI 颜色 ──
 class C:
@@ -213,7 +215,7 @@ def play_boot_sequence() -> None:
 
     _print(f"  {C.CYAN}╭{'─' * 56}╮{C.RESET}")
     _print(
-        f"  {C.CYAN}│{C.RESET}  {C.WHITE}{C.BOLD}🧠 Noosphere MCP Server v0.4.0{C.RESET}                       {C.CYAN}│{C.RESET}"
+        f"  {C.CYAN}│{C.RESET}  {C.WHITE}{C.BOLD}🧠 Noosphere MCP Server v{__version__}{C.RESET}                       {C.CYAN}│{C.RESET}"
     )
     _print(
         f"  {C.CYAN}│{C.RESET}  {C.DIM}The Collective Consciousness Network{C.RESET}                  {C.CYAN}│{C.RESET}"


### PR DESCRIPTION
## Summary
- align Codex and Claude plugin manifests with public MCP v0.8.3 and the canonical 14-Skill registry
- rename the marketplace entry to Noosphere Live Skills and refresh launch-facing counts
- fix the Codex plugin MCP companion schema from legacy mcp_servers to mcpServers
- add repository validation and regression coverage for version, count, and MCP schema drift
- update the project memory snapshot with the verified launch state

## Verification
- 208 SDK tests passed
- 93 Node supply-chain tests passed
- 50 repository script tests passed
- Codex bundled plugin validator passed
- Claude plugin validator passed
- Ruff and repository metadata validation passed
- public noosphere-mcp==0.8.3 validation passed on Windows

GitHub Topics were updated separately through the repository API and verified live.