### PR TITLE
fix: make Skill Evidence intake single-path

### DIFF
--- a/.github/scripts/promotion-integrity.cjs
+++ b/.github/scripts/promotion-integrity.cjs
@@ -77,13 +77,28 @@ function hasPromotionComment(comments, issueNumber) {
   ));
 }
 
+function reviewPauseCommentMarker(issueNumber) {
+  const normalizedIssue = positiveIssueNumber(issueNumber);
+  if (!normalizedIssue) throw new Error("A positive source Issue number is required");
+  return `<!-- noosphere-review-pause:issue-${normalizedIssue} -->`;
+}
+
+function hasReviewPauseComment(comments, issueNumber) {
+  const marker = reviewPauseCommentMarker(issueNumber);
+  return Array.isArray(comments) && comments.some((comment) => (
+    String(comment?.body || "").includes(marker)
+  ));
+}
+
 module.exports = {
   buildTombstoneManifest,
   canonicalPromotionPath,
   extractWithdrawalRequest,
   findExistingPromotion,
   hasPromotionComment,
+  hasReviewPauseComment,
   isIssueTombstoned,
   positiveIssueNumber,
   promotionCommentMarker,
+  reviewPauseCommentMarker,
 };

--- a/.github/scripts/promotion-integrity.test.cjs
+++ b/.github/scripts/promotion-integrity.test.cjs
@@ -9,8 +9,10 @@ const {
   extractWithdrawalRequest,
   findExistingPromotion,
   hasPromotionComment,
+  hasReviewPauseComment,
   isIssueTombstoned,
   promotionCommentMarker,
+  reviewPauseCommentMarker,
 } = require("./promotion-integrity.cjs");
 
 test("uses one deterministic promotion path per source issue", () => {
@@ -53,6 +55,13 @@ test("uses a stable marker to reconcile the promotion success comment", () => {
   assert.equal(marker, "<!-- noosphere-promotion:issue-27 -->");
   assert.equal(hasPromotionComment([{ body: `done\n${marker}` }], 27), true);
   assert.equal(hasPromotionComment([{ body: "unrelated" }], 27), false);
+});
+
+test("uses one stable review-pause comment across workflow retries", () => {
+  const marker = reviewPauseCommentMarker(69);
+  assert.equal(marker, "<!-- noosphere-review-pause:issue-69 -->");
+  assert.equal(hasReviewPauseComment([{ body: `paused\n${marker}` }], 69), true);
+  assert.equal(hasReviewPauseComment([{ body: "unrelated" }], 69), false);
 });
 
 test("builds an idempotent tombstone manifest", () => {
@@ -106,6 +115,12 @@ test("promotion workflow reuses an existing source Issue promotion", () => {
   assert.match(workflow, /canonicalPromotionPath/);
   assert.match(workflow, /existingPromotion\?\.path/);
   assert.match(workflow, /hasPromotionComment/);
+  assert.match(workflow, /hasReviewPauseComment/);
+  assert.match(workflow, /reviewPauseCommentMarker/);
+  assert.match(
+    workflow,
+    /github\.event\.action == 'opened'.*github\.event\.label\.name == 'trusted-review'/s,
+  );
   assert.match(workflow, /git fetch origin main/);
   assert.doesNotMatch(workflow, /skipping duplicate write[\s\S]*?return;/);
 });

--- a/.github/workflows/consciousness_promote.yml
+++ b/.github/workflows/consciousness_promote.yml
@@ -1,4 +1,4 @@
-name: 🌌 Consciousness Promotion (意识晋升流水线)
+name: 🌌 Noosphere Contribution Promotion
 
 # Trigger on Issue creation or labeling. The job parses the Issue body and only
 # promotes Issues that contain a recognized Noosphere payload.
@@ -18,9 +18,11 @@ permissions:
 
 jobs:
   promote_consciousness:
-    name: 🧠 Validate & Promote Consciousness
+    name: 🧠 Validate & Route Contribution
     runs-on: ubuntu-latest
-    if: github.event.issue.state == 'open'
+    if: >-
+      github.event.issue.state == 'open' &&
+      (github.event.action == 'opened' || github.event.label.name == 'trusted-review')
 
     steps:
       - name: 🌐 Checkout Repository
@@ -174,8 +176,10 @@ jobs:
               canonicalPromotionPath,
               findExistingPromotion,
               hasPromotionComment,
+              hasReviewPauseComment,
               isIssueTombstoned,
               promotionCommentMarker,
+              reviewPauseCommentMarker,
             } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/promotion-integrity.cjs`);
             const {
               assessSkillEligibility,
@@ -224,6 +228,14 @@ jobs:
                   });
                 } catch (error) {
                   if (error.status !== 422) throw error;
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name,
+                    new_name: name,
+                    color,
+                    description,
+                  });
                 }
               }
             }
@@ -262,12 +274,20 @@ jobs:
                 issue_number: issue.number,
                 labels: ['needs-review'],
               });
-              await github.rest.issues.createComment({
+              const pauseComments = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `Promotion paused: ${reason}. A repository maintainer must review the payload and add the trusted-review label.`,
+                per_page: 100,
               });
+              if (!hasReviewPauseComment(pauseComments.data, issue.number)) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `Promotion paused: ${reason}. A repository maintainer must review the payload and add the trusted-review label.\n\n${reviewPauseCommentMarker(issue.number)}`,
+                });
+              }
               core.setOutput('promoted', 'false');
             }
 

--- a/sdk/noosphere/noosphere_mcp.py
+++ b/sdk/noosphere/noosphere_mcp.py
@@ -6473,11 +6473,6 @@ async def submit_skill_evidence(
             f"{hashlib.sha256(identity.encode('utf-8')).hexdigest()[:24]}"
         )
         marker = f"<!-- SKILL_EVIDENCE_ID:{evidence_id} -->"
-        track_label = (
-            "awaiting-independent-evidence"
-            if publication_track == "community"
-            else "maintainer-skill-proposal"
-        )
         next_state = (
             "awaiting-review-and-independent-reproduction"
             if publication_track == "community"
@@ -6550,17 +6545,8 @@ async def submit_skill_evidence(
             json={
                 "title": f"Shared Skill Evidence: {skill_name} by {authenticated_user}",
                 "body": body,
-                "labels": ["skill-evidence", "needs-review", track_label],
             },
         )
-        if response.status_code == 422:
-            response = await client.post(
-                f"/repos/{owner}/{repo}/issues",
-                json={
-                    "title": f"Shared Skill Evidence: {skill_name} by {authenticated_user}",
-                    "body": body,
-                },
-            )
         if response.status_code != 201:
             message = response.json().get("message", "Unknown error")
             return f"❌ Failed to submit Skill evidence: {message}"

--- a/sdk/tests/test_shared_skills.py
+++ b/sdk/tests/test_shared_skills.py
@@ -287,12 +287,7 @@ async def test_submit_skill_evidence_creates_distinct_idempotent_record():
     assert issue_route.call_count == 1
     assert submitted["title"].startswith("Shared Skill Evidence:")
     assert "Consciousness Leap" not in submitted["title"]
-    assert "consciousness" not in submitted["labels"]
-    assert submitted["labels"] == [
-        "skill-evidence",
-        "needs-review",
-        "awaiting-independent-evidence",
-    ]
+    assert "labels" not in submitted
     assert '"record_kind": "skill-evidence"' in submitted["body"]
     assert '"proposed_skill": "codex-project-recency-sort-recovery"' in submitted["body"]
     assert "not a consciousness fragment" in submitted["body"]


### PR DESCRIPTION
## Real-test finding

The first live `submit_skill_evidence` run created Issue #69 correctly, but attaching three lifecycle labels during Issue creation produced `opened + labeled×3` events. Serialized jobs used stale event snapshots and emitted four duplicate review-pause comments before the trusted-review event created candidate #70.

## Fix

- create the Evidence Issue without lifecycle labels; the trusted workflow owns label projection
- run the promotion job only for `opened` and `trusted-review` events
- make review-pause comments idempotent with a stable marker
- update existing lifecycle label metadata instead of accepting default gray labels
- rename the job to contribution-neutral wording

## Verification

- 213 SDK tests
- 102 Node workflow/supply-chain tests
- workflow YAML parse
- registry validation and `git diff --check`

After merge, a second real Evidence submission will verify that the intake produces one active promotion job and one review-pause comment before trusted review.