### PR TITLE
fix: decouple dynamic Skill publication from static counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Noosphere connects coding Agents to one live Skill registry. When a concrete fai
 occurs, the Agent discovers an applicable reviewed Skill, verifies its exact artifact,
 checks local applicability, and runs the real project verification before claiming success.
 
-[![Live Skills](https://img.shields.io/badge/Live_Skills-14-8d7cff?style=for-the-badge)](docs/live-skills.md)
-[![Registry](https://img.shields.io/badge/Registry-r4-55d7e5?style=for-the-badge)](shared_skills/registry.json)
+[![Live Skills](https://img.shields.io/badge/Live_Skills-live-8d7cff?style=for-the-badge)](docs/live-skills.md)
+[![Registry](https://img.shields.io/badge/Registry-dynamic-55d7e5?style=for-the-badge)](shared_skills/registry.json)
 [![Release](https://img.shields.io/badge/Release-v0.9.1-68df9b?style=for-the-badge)](https://github.com/JinNing6/Noosphere/releases/tag/v0.9.1)
 [![PyPI](https://img.shields.io/pypi/v/noosphere-mcp?style=for-the-badge&logo=pypi&logoColor=white)](https://pypi.org/project/noosphere-mcp/)
 
@@ -48,7 +48,7 @@ frame the failure -> discover applicable Live Skills -> verify exact SHA-256
   <sub>Time-compressed reconstruction from real public <code>noosphere-mcp==0.9.0</code> query and validation output.</sub>
 </div>
 
-The plugin does **not** bundle static copies of the 14 engineering Skills. They remain in
+The plugin does **not** bundle static copies of the engineering Skills. They remain in
 one review-gated live registry, so a reviewed Skill update is available to every connected
 Agent without reinstalling the plugin. Read-only discovery works anonymously. Creating
 public memory or Outcome records always requires authentication and explicit user consent.
@@ -91,7 +91,7 @@ Add a GitHub token only for fresher Issue-layer results, uploads, feedback, or h
 | Inspect the live system | Path |
 |---|---|
 | Immutable Skill registry | [`shared_skills/registry.json`](shared_skills/registry.json) |
-| 14 Live engineering Skills | [Catalog](docs/live-skills.md) · [active mirrors](shared_skills/active/) |
+| Live engineering Skills | [Catalog](docs/live-skills.md) · [active mirrors](shared_skills/active/) |
 | Immutable releases | [`shared_skills/releases/<version>/<name>/SKILL.md`](shared_skills/releases/) |
 | Founding evidence | [Issues #35](https://github.com/JinNing6/Noosphere/issues/35), [#36](https://github.com/JinNing6/Noosphere/issues/36), [#37](https://github.com/JinNing6/Noosphere/issues/37) |
 | Supply-chain protocol | [`SKILLS_PROTOCOL.md`](SKILLS_PROTOCOL.md) |
@@ -139,7 +139,7 @@ failure -> verified fix -> public Skill evidence -> independent reproduction
         -> execution outcome -> update or reviewed rollback
 ```
 
-Noosphere does not auto-execute community prompts. Its 14 maintainer-validated Live Skills are
+Noosphere does not auto-execute community prompts. Its maintainer-validated Live Skills are
 immutable `1.0.0` releases with maintainer provenance and SHA-256 verification. New
 community Skills and updates require structured root-cause evidence, two independent
 publishers, maintainer review, outcome feedback, and rollback. A separate maintainer
@@ -317,7 +317,7 @@ Ordinary Skill files teach one Agent a workflow. Noosphere gives every Skill one
 
 The public read surface is `list_shared_skills`, `get_shared_skill`, and `check_skill_updates`. After explicit user consent, authenticated Agents submit reusable engineering evidence through `submit_skill_evidence`; the result reports whether it is only recorded, awaiting independent reproduction, or has produced a candidate. `upload_consciousness` remains reserved for general thoughts rather than software fixes. Authenticated users can submit idempotent execution feedback through `record_skill_outcome`; trusted review records it in the public outcome ledger. Only an independent success with public evidence advances proven reuse; partial or failed outcomes mark an update-needed boundary without rewriting immutable instructions. Rollback requests remain separately review-gated through `request_shared_skill_withdrawal`. See [the protocol and trust boundary](SKILLS_PROTOCOL.md).
 
-The registry contains 14 Live Skills at `maintainer-validated`. Noosphere will not claim independent reproduction until two independent publishers provide structured evidence, a deterministic candidate is generated, and a maintainer approves the immutable next release.
+The registry exposes each active Live Skill with an explicit verification level. Noosphere will not claim independent reproduction until two independent publishers provide structured evidence, a deterministic candidate is generated, and a maintainer approves the immutable next release.
 
 ---
 
@@ -353,7 +353,7 @@ What the plugin gives Codex:
 | `submit_skill_evidence` via MCP | After explicit consent, record a verified engineering fix in the Shared Skill lifecycle. |
 | `upload_consciousness` via MCP | Share general thoughts and philosophical consciousness fragments, not engineering fixes. |
 | Dynamic shared Skill tools | Tolerantly rank approved releases, verify exact digests, check updates, report outcomes, and request reviewed rollback. |
-| 14 Live engineering Skills | Discover and retrieve versioned debugging, CI, release, frontend, infrastructure, backend, security, and Noosphere workflows from the shared registry. [Browse the catalog.](docs/live-skills.md) |
+| Live engineering Skills | Discover and retrieve versioned debugging, CI, release, frontend, infrastructure, backend, security, and Noosphere workflows from the shared registry. [Browse the catalog.](docs/live-skills.md) |
 
 **Install first. Spread by real bug saves. Let every fixed failure become distribution.**
 
@@ -383,7 +383,7 @@ The Claude plugin bundles:
 |---|---|
 | `mcpServers.noosphere` | Starts `uvx noosphere-mcp` automatically when the plugin is enabled. |
 | `userConfig.github_token` | Optional sensitive GitHub token for uploads and higher rate limits; public consultation works without manual JSON edits. |
-| 14 Live engineering Skills | The same versioned registry available to Codex, Claude Code, and every MCP client without plugin-local copies. [Browse the catalog.](docs/live-skills.md) |
+| Live engineering Skills | The same versioned registry available to Codex, Claude Code, and every MCP client without plugin-local copies. [Browse the catalog.](docs/live-skills.md) |
 | Dynamic shared Skill MCP tools | Lists, retrieves, updates, reports, and requests rollback through the versioned registry. |
 | `/noosphere:noosphere-consult` and `/noosphere:noosphere-upload` | Manual slash commands for explicit memory search and upload. |
 
@@ -886,7 +886,7 @@ Unlike the old world, the Community of Consciousness continuously evolves. When 
 | `uvx` / `npx` (Recommended) | ⚡ **Auto Evolve** | Just restart the IDE / MCP client. `uvx` automatically pulls the latest version on launch |
 | `pip install` (Manual) | 🔧 Manual Upgrade | Execute `pip install --upgrade noosphere-mcp`, then restart IDE |
 
-Maintainer release path for the unified live registry: publish a semantic GitHub Release such as `v0.9.1` from the intended `main` commit. The single `release.published` trigger runs `.github/workflows/publish-pypi.yml`, which builds `noosphere-mcp` with SDK, workflow, validation-kit, and shared Skill supply-chain tests, then publishes through PyPI Trusted Publishing/OIDC without a stored `PYPI_TOKEN`; after the PyPI verifier performs a real anonymous `initialize + tools/list` handshake and the sub-60-second validation command against a clean installed runtime, it dispatches `.github/workflows/deploy-pages.yml` on `main` so GitHub Pages refreshes the public evidence and Skill indexes. Do not push the release tag separately: creating a GitHub Release also creates its tag, and two configured triggers would race to publish the same immutable PyPI version. After PyPI shows `0.9.1`, `uvx noosphere-mcp`, `uvx --from noosphere-mcp noosphere-query "your error"`, `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate`, and `pip install --upgrade noosphere-mcp` deliver the 46 MCP tools, 14 live Skill registry entries, zero-configuration read-only query, and the prefilled independent-validation path.
+Maintainer release path for the unified live registry: publish a semantic GitHub Release such as `v0.9.1` from the intended `main` commit. The single `release.published` trigger runs `.github/workflows/publish-pypi.yml`, which builds `noosphere-mcp` with SDK, workflow, validation-kit, and shared Skill supply-chain tests, then publishes through PyPI Trusted Publishing/OIDC without a stored `PYPI_TOKEN`; after the PyPI verifier performs a real anonymous `initialize + tools/list` handshake and the sub-60-second validation command against a clean installed runtime, it dispatches `.github/workflows/deploy-pages.yml` on `main` so GitHub Pages refreshes the public evidence and Skill indexes. Do not push the release tag separately: creating a GitHub Release also creates its tag, and two configured triggers would race to publish the same immutable PyPI version. After PyPI shows `0.9.1`, `uvx noosphere-mcp`, `uvx --from noosphere-mcp noosphere-query "your error"`, `uvx --from noosphere-mcp noosphere-validate public-artifact-runtime-smoke-gate`, and `pip install --upgrade noosphere-mcp` deliver the 46 MCP tools, the current live Skill registry, zero-configuration read-only query, and the prefilled independent-validation path.
 
 > 💡 **How to check**: Look at your MCP config. If `command` is `"uvx"`, you are in Auto Evolve mode; if `"python"`, you are in Manual mode.
 >

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,8 +11,8 @@
 Noosphere 将 Coding Agent 连接到同一个持续更新的 Skill 注册表。遇到具体故障时，Agent 会自动
 发现适用的审核后 Skill、校验精确制品、检查本地适用性，并在声称成功前运行真实项目验证。
 
-[![Live Skills](https://img.shields.io/badge/Live_Skills-14-8d7cff?style=for-the-badge)](docs/live-skills.md)
-[![注册表](https://img.shields.io/badge/注册表-r4-55d7e5?style=for-the-badge)](shared_skills/registry.json)
+[![Live Skills](https://img.shields.io/badge/Live_Skills-live-8d7cff?style=for-the-badge)](docs/live-skills.md)
+[![注册表](https://img.shields.io/badge/注册表-dynamic-55d7e5?style=for-the-badge)](shared_skills/registry.json)
 [![版本](https://img.shields.io/badge/版本-v0.9.1-68df9b?style=for-the-badge)](https://github.com/JinNing6/Noosphere/releases/tag/v0.9.1)
 [![PyPI](https://img.shields.io/pypi/v/noosphere-mcp?style=for-the-badge&logo=pypi&logoColor=white)](https://pypi.org/project/noosphere-mcp/)
 
@@ -46,7 +46,7 @@ Codex 会在遇到具体软件故障时隐式启用 `using-noosphere` 控制 Ski
   <sub>基于公开 <code>noosphere-mcp==0.9.0</code> 真实查询与验证输出制作的时间压缩重建。</sub>
 </div>
 
-插件不会复制 14 个动态工程 Skills；它们始终归属于同一个审核门禁注册表，因此审核后的
+插件不会复制动态工程 Skills；它们始终归属于同一个审核门禁注册表，因此审核后的
 Skill 更新会直接提供给所有已连接 Agent，无需重新安装插件。匿名只读检索不需要 Token；
 创建公开 Skill 证据、意识内容或 Outcome 始终需要身份认证和用户当次明确同意。工程修复
 进入独立 Skill Evidence 层，不再上传为意识体。
@@ -87,7 +87,7 @@ uvx --from noosphere-mcp==0.9.0 noosphere-query "React Three Fiber mobile glowin
 | 检查真实系统 | 路径 |
 |---|---|
 | 不可变 Skill 注册表 | [`shared_skills/registry.json`](shared_skills/registry.json) |
-| 14 个持续更新的工程 Skills | [目录](docs/live-skills.md) · [当前版本镜像](shared_skills/active/) |
+| 持续更新的工程 Skills | [目录](docs/live-skills.md) · [当前版本镜像](shared_skills/active/) |
 | 不可变版本 | [`shared_skills/releases/<version>/<name>/SKILL.md`](shared_skills/releases/) |
 | 首批真实证据 | [#35](https://github.com/JinNing6/Noosphere/issues/35)、[#36](https://github.com/JinNing6/Noosphere/issues/36)、[#37](https://github.com/JinNing6/Noosphere/issues/37) |
 | 供应链协议 | [`SKILLS_PROTOCOL.md`](SKILLS_PROTOCOL.md) |
@@ -126,7 +126,7 @@ uvx --from 'noosphere-mcp[semantic]' noosphere-mcp
      -> 不可变 SKILL.md -> 摘要校验后调用 -> 结果反馈 -> 更新或审核回滚
 ```
 
-Noosphere 不会直接执行社区提示词。14 个维护者验证的 Live Skills 已作为不可变 `1.0.0` 版本进入
+Noosphere 不会直接执行社区提示词。维护者验证的 Live Skills 以不可变版本进入
 同一个持续更新的注册表，带维护者来源和 SHA-256 校验。新的社区 Skill 或更新版本仍必须具备
 结构化根因证据、两个独立发布者、人工审核、结果反馈和回滚能力。单一维护者证据可以走
 独立轨道，但必须经过另一位可信审核者，并明确标记为 `maintainer-validated`。2 个剩余的已验证 Seeds

--- a/docs/live-skills.md
+++ b/docs/live-skills.md
@@ -1,6 +1,6 @@
 # Live Engineering Skills
 
-Noosphere publishes 14 maintainer-validated Agent Skills through one live, versioned registry. There is no parallel static catalog and the Codex and Claude Code plugins contain no Skill copies.
+Noosphere publishes approved Agent Skills through one live, versioned registry. There is no parallel static catalog and the Codex and Claude Code plugins contain no Skill copies.
 
 Every active Skill has:
 

--- a/plugins/claude-noosphere/README.md
+++ b/plugins/claude-noosphere/README.md
@@ -2,7 +2,7 @@
 
 Noosphere makes reviewed shared fixes available automatically when Claude Code encounters a concrete software failure.
 
-The plugin connects Claude Code to one live registry containing 14 Agent Skills:
+The plugin connects Claude Code to one live registry of approved Agent Skills:
 
 - one plugin-local `using-noosphere` control Skill for safe automatic discovery and use
 - a fast `SessionStart` hook that restores the activation contract after startup, resume, clear, or compaction

--- a/plugins/claude-noosphere/SUBMISSION.md
+++ b/plugins/claude-noosphere/SUBMISSION.md
@@ -23,7 +23,7 @@ Install once. Claude Code automatically discovers, digest-verifies, applies, and
 Long description:
 
 ```text
-Noosphere turns verified debugging lessons into shared agent memory and live, review-gated Agent Skills. Claude Code can discover 14 versioned foundational Skills automatically when a concrete software failure occurs, verify exact digests, check applicability and updates, run local verification, and report execution outcomes only with explicit consent. The plugin contains one control Skill, a bounded SessionStart hook, the MCP connection, and optional manual commands; all dynamic engineering Skills remain in one public immutable registry.
+Noosphere turns verified debugging lessons into shared agent memory and live, review-gated Agent Skills. Claude Code can discover approved versioned foundational Skills automatically when a concrete software failure occurs, verify exact digests, check applicability and updates, run local verification, and report execution outcomes only with explicit consent. The plugin contains one control Skill, a bounded SessionStart hook, the MCP connection, and optional manual commands; all dynamic engineering Skills remain in one public immutable registry.
 ```
 
 ## Review Notes

--- a/plugins/noosphere/.codex-plugin/plugin.json
+++ b/plugins/noosphere/.codex-plugin/plugin.json
@@ -24,7 +24,7 @@
   "interface": {
     "displayName": "Noosphere",
     "shortDescription": "Automatically apply verified shared fixes.",
-    "longDescription": "Install once and Codex automatically checks one live registry before debugging concrete software failures. Discover 14 versioned engineering workflows through a single control Skill that verifies exact digests, checks local applicability, runs project verification, and keeps public outcome reporting consent-gated.",
+    "longDescription": "Install once and Codex automatically checks one live registry before debugging concrete software failures. Discover approved versioned engineering workflows through a single control Skill that verifies exact digests, checks local applicability, runs project verification, and keeps public outcome reporting consent-gated.",
     "developerName": "JinNing6",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/noosphere/README.md
+++ b/plugins/noosphere/README.md
@@ -2,7 +2,7 @@
 
 Noosphere makes reviewed shared fixes available automatically when Codex encounters a concrete software failure.
 
-The plugin connects Codex to one live registry containing 14 Agent Skills:
+The plugin connects Codex to one live registry of approved Agent Skills:
 
 - one plugin-local `using-noosphere` control Skill that triggers discovery, digest verification, applicability checks, and project verification
 - Noosphere MCP tools through `uvx noosphere-mcp`

--- a/scripts/test_launch_surface.py
+++ b/scripts/test_launch_surface.py
@@ -11,14 +11,16 @@ CLAUDE_INSTALL = "/plugin marketplace add JinNing6/Noosphere"
 
 
 class LaunchSurfaceTests(unittest.TestCase):
-    def test_registry_count_matches_the_honest_first_screen_claim(self):
+    def test_first_screen_projects_a_dynamic_registry_without_count_drift(self):
         registry = json.loads(
             (REPO_ROOT / "shared_skills" / "registry.json").read_text(encoding="utf-8")
         )
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertEqual(len(registry["skills"]), 14)
-        self.assertIn("Live_Skills-14", readme)
+        self.assertGreaterEqual(len(registry["skills"]), 14)
+        self.assertIn("Live_Skills-live", readme)
+        self.assertIn("Registry-dynamic", readme)
+        self.assertNotRegex(readme, r"Live_Skills-\d+")
         self.assertIn("docs/live-skills.md", readme)
         self.assertIn("maintainer-validated Live Skills", readme)
         self.assertIn("public-artifact-runtime-smoke-gate", readme)
@@ -28,7 +30,15 @@ class LaunchSurfaceTests(unittest.TestCase):
                 for item in skill["releases"]
                 if item["version"] == skill["latest"] and item["status"] == "active"
             )
-            self.assertEqual(release["verification"]["level"], "maintainer-validated")
+            self.assertIn(
+                release["verification"]["level"],
+                {
+                    "maintainer-validated",
+                    "independently-reproduced",
+                    "outcome-proven",
+                    "established",
+                },
+            )
 
     def test_english_and_chinese_first_screens_lead_with_automatic_agent_install(self):
         for name in ("README.md", "README.zh-CN.md"):

--- a/scripts/test_validate_shared_skills.py
+++ b/scripts/test_validate_shared_skills.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -296,6 +297,27 @@ class SharedSkillValidationTests(unittest.TestCase):
         root = Path(__file__).resolve().parents[1]
 
         self.assertEqual(validate_plugin_bootstrap(root), [])
+
+    def test_dynamic_registry_surfaces_do_not_hardcode_active_skill_count(self):
+        root = Path(__file__).resolve().parents[1]
+        surfaces = [
+            root / "plugins/noosphere/.codex-plugin/plugin.json",
+            root / "plugins/noosphere/README.md",
+            root / "plugins/claude-noosphere/README.md",
+            root / "plugins/claude-noosphere/SUBMISSION.md",
+        ]
+
+        for path in surfaces:
+            text = path.read_text(encoding="utf-8")
+            self.assertIsNone(
+                re.search(
+                    r"\b\d+\s+(?:versioned\s+(?:foundational\s+)?|live\s+)?"
+                    r"(?:Agent\s+)?Skills\b",
+                    text,
+                    re.IGNORECASE,
+                ),
+                path,
+            )
 
     def test_plugins_must_not_bundle_dynamic_skill_copies(self):
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/validate_shared_skills.py
+++ b/scripts/validate_shared_skills.py
@@ -448,33 +448,29 @@ def validate_repository(root: Path) -> list[str]:
                     f"plugins={sorted(str(value) for value in versions)}"
                 )
 
-        active_skill_count = sum(
-            1
-            for skill in registry.get("skills", [])
-            if isinstance(skill, dict) and skill.get("latest")
-        )
         codex_description = manifests[0].get("interface", {}).get("longDescription", "")
-        expected_description = f"Discover {active_skill_count} versioned"
+        expected_description = "Discover approved versioned"
         if expected_description not in codex_description:
             errors.append(
-                f"Codex plugin Skill count drift: expected `{expected_description}`"
+                "Codex plugin must describe dynamic registry discovery: "
+                f"expected `{expected_description}`"
             )
 
-        count_copy = [
+        dynamic_registry_copy = [
             (
                 root / "plugins" / "noosphere" / "README.md",
-                f"containing {active_skill_count} Agent Skills",
+                "live registry of approved Agent Skills",
             ),
             (
                 root / "plugins" / "claude-noosphere" / "README.md",
-                f"containing {active_skill_count} Agent Skills",
+                "live registry of approved Agent Skills",
             ),
             (
                 root / "plugins" / "claude-noosphere" / "SUBMISSION.md",
-                f"discover {active_skill_count} versioned foundational Skills",
+                "discover approved versioned foundational Skills",
             ),
         ]
-        for path, expected in count_copy:
+        for path, expected in dynamic_registry_copy:
             try:
                 text = path.read_text(encoding="utf-8")
             except OSError as exc:
@@ -482,7 +478,8 @@ def validate_repository(root: Path) -> list[str]:
                 continue
             if expected not in text:
                 errors.append(
-                    f"Plugin Skill count drift in {path}: expected `{expected}`"
+                    f"Plugin must describe dynamic registry discovery in {path}: "
+                    f"expected `{expected}`"
                 )
     codex_mcp_path = root / "plugins" / "noosphere" / ".mcp.json"
     try:


### PR DESCRIPTION
## Real-test finding

The first approved maintainer candidate (#70) staged its immutable release successfully, but publication validation failed because plugin copy and launch tests hardcoded the current registry size (`14`). A dynamic registry could not grow to 15 without manually editing unrelated marketing copy.

## Fix

- describe the catalog as a live registry of approved versioned Skills, without a static count
- validate the dynamic discovery contract instead of mirroring registry cardinality into plugin copy
- allow every declared verification maturity on the live surface
- replace count/revision badges with stable live/dynamic badges
- add regressions forbidding hardcoded active-Skill counts on plugin surfaces

## Verification

- 55 repository Python tests
- 102 Node workflow/supply-chain tests
- registry and plugin validation
- Ruff lint and `git diff --check`

After merge, candidate #70 will be retriggered and must publish `shared-skill-evidence-routing@1.0.0` without changing plugin copy.