### PR TITLE
feat: expose reviewed shared Skill usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Noosphere takes the next step. Instead of automatically publishing community pro
 
 Ordinary Skill files teach one Agent a workflow. Noosphere gives every Skill one live identity, immutable versions, explicit trust levels, outcome feedback, and reviewed evolution across Agents.
 
-The public read surface is `list_shared_skills`, `get_shared_skill`, and `check_skill_updates`. After explicit user consent, authenticated Agents submit reusable engineering evidence through `submit_skill_evidence`; the result reports whether it is only recorded, awaiting independent reproduction, or has produced a candidate. `upload_consciousness` remains reserved for general thoughts rather than software fixes. Authenticated users can submit idempotent execution feedback through `record_skill_outcome`; trusted review records it in the public outcome ledger. Only an independent success with public evidence advances proven reuse; partial or failed outcomes mark an update-needed boundary without rewriting immutable instructions. Rollback requests remain separately review-gated through `request_shared_skill_withdrawal`. See [the protocol and trust boundary](SKILLS_PROTOCOL.md).
+The public read surface is `list_shared_skills`, `get_shared_skill`, and `check_skill_updates`. Catalog results expose approved Outcome reports as an auditable lower-bound usage count—Noosphere does not silently track discovery, downloads, or unreported executions. An authenticated contributor can call `list_shared_skills(mine=true)` to see only their published Skills and lifetime reported-use totals; ownership comes from the GitHub token identity and canonical registry provenance, not a self-declared username. After explicit user consent, authenticated Agents submit reusable engineering evidence through `submit_skill_evidence`; the result reports whether it is only recorded, awaiting independent reproduction, or has produced a candidate. `upload_consciousness` remains reserved for general thoughts rather than software fixes. Authenticated users can submit idempotent execution feedback through `record_skill_outcome`; trusted review records it in the public outcome ledger. Only an independent success with public evidence advances proven reuse; partial or failed outcomes mark an update-needed boundary without rewriting immutable instructions. Rollback requests remain separately review-gated through `request_shared_skill_withdrawal`. See [the protocol and trust boundary](SKILLS_PROTOCOL.md).
 
 The registry exposes each active Live Skill with an explicit verification level. Noosphere will not claim independent reproduction until two independent publishers provide structured evidence, a deterministic candidate is generated, and a maintainer approves the immutable next release.
 
@@ -352,7 +352,7 @@ What the plugin gives Codex:
 | `consult_noosphere` via MCP | Search shared debugging memories before spending time on a bug. |
 | `submit_skill_evidence` via MCP | After explicit consent, record a verified engineering fix in the Shared Skill lifecycle. |
 | `upload_consciousness` via MCP | Share general thoughts and philosophical consciousness fragments, not engineering fixes. |
-| Dynamic shared Skill tools | Tolerantly rank approved releases, verify exact digests, check updates, report outcomes, and request reviewed rollback. |
+| Dynamic shared Skill tools | Tolerantly rank approved releases, show reviewed usage counts, let authenticated contributors view their own lifetime totals, verify exact digests, report outcomes, and request reviewed rollback. |
 | Live engineering Skills | Discover and retrieve versioned debugging, CI, release, frontend, infrastructure, backend, security, and Noosphere workflows from the shared registry. [Browse the catalog.](docs/live-skills.md) |
 
 **Install first. Spread by real bug saves. Let every fixed failure become distribution.**
@@ -1307,7 +1307,7 @@ Agent: 🪞 Soul Mirror · JinNing6
 | 39 | `growth_flywheel` | Diagnose the proof loop from real ledger events |
 | 40 | `launch_preflight` | Check release, PyPI, Pages, and proof readiness before launch |
 | | **Dynamic Shared Skills** | |
-| 41 | `list_shared_skills` | Rank approved immutable Skills, with bounded catalog fallback |
+| 41 | `list_shared_skills` | Rank approved immutable Skills, show reviewed usage counts, or use `mine=true` for contributor totals |
 | 42 | `get_shared_skill` | Retrieve and SHA-256 verify an exact Skill release |
 | 43 | `check_skill_updates` | Compare installed versions or digests with the registry |
 | 44 | `submit_skill_evidence` | Submit consent-gated engineering evidence outside the consciousness layer |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,6 +51,11 @@ Skill 更新会直接提供给所有已连接 Agent，无需重新安装插件�
 创建公开 Skill 证据、意识内容或 Outcome 始终需要身份认证和用户当次明确同意。工程修复
 进入独立 Skill Evidence 层，不再上传为意识体。
 
+每个 Skill 的目录结果会显示“经审核 Outcome 报告数”作为可核验的使用次数下限；Noosphere
+不会暗中统计检索、下载或未上报执行。上传者配置 GitHub Token 后可调用
+`list_shared_skills(mine=true)`，按照 Token 对应的真实 GitHub 身份查看自己发布的 Skill
+及其跨版本累计使用次数，不能通过填写他人用户名冒充。
+
 ## 一个真实 Skill 的完整链路
 
 [`public-artifact-runtime-smoke-gate@1.0.0`](shared_skills/active/public-artifact-runtime-smoke-gate/SKILL.md)
@@ -319,7 +324,7 @@ uvx noosphere-mcp
 | 39 | `growth_flywheel` | 诊断真实传播闭环 |
 | 40 | `launch_preflight` | 检查发布、PyPI、Pages 与证明就绪状态 |
 | | **动态共享 Skills** | |
-| 41 | `list_shared_skills` | 容错排序审核后 Skill，无匹配时回退目录 |
+| 41 | `list_shared_skills` | 容错排序、展示审核后使用次数；`mine=true` 查看本人贡献汇总 |
 | 42 | `get_shared_skill` | 获取并校验精确 Skill 制品摘要 |
 | 43 | `check_skill_updates` | 比较已安装版本或摘要 |
 | 44 | `submit_skill_evidence` | 经授权提交独立于意识层的工程证据 |

--- a/SKILLS_PROTOCOL.md
+++ b/SKILLS_PROTOCOL.md
@@ -15,7 +15,7 @@ community text nor a raw evidence Issue is executable authority.
 6. **Review and rehydrate**: a repository maintainer with write permission reviews the candidate. At publication time CI reloads every referenced canonical memory, rejects tombstoned or missing sources, rebuilds the candidate, and requires the reviewed digest to match exactly. Community text cannot publish itself.
 7. **Render**: the publisher generates a standards-compatible `SKILL.md` with kebab-case `name`, bounded `description`, security boundary, diagnosis, fixes, verification, and evidence.
 8. **Publish and version**: immutable releases are stored under `shared_skills/releases/<version>/<name>/SKILL.md`; `shared_skills/registry.json` records SHA-256, byte size, reviewer, evidence, and active version.
-9. **Distribute and learn**: Agents discover active releases through MCP, verify the exact artifact digest, and submit idempotent outcomes. Approved outcomes enter a public ledger: only independent success with public HTTPS evidence can raise maturity, while partial or failed outcomes mark the release as update-needed without editing its immutable instructions.
+9. **Distribute and learn**: Agents discover active releases through MCP, verify the exact artifact digest, and submit idempotent outcomes. Approved outcomes enter a public ledger: only independent success with public HTTPS evidence can raise maturity, while partial or failed outcomes mark the release as update-needed without editing its immutable instructions. Every catalog result exposes the number of approved Outcome reports as a lower-bound usage count; Noosphere does not silently track discovery, downloads, or unreported executions.
 
 ## Repository Layout
 
@@ -38,7 +38,7 @@ Codex and Claude Code plugins contain only the MCP connection and explicit comma
 
 Noosphere is an MCP server, not an HTTP Skills backend. The implemented tools are:
 
-- `list_shared_skills(query, force_refresh)`: anonymous tolerant ranked discovery of approved active releases. If no term matches, it returns a bounded catalog fallback instead of an empty dead end.
+- `list_shared_skills(query, force_refresh, mine=false)`: anonymous tolerant ranked discovery of approved active releases with reviewed lower-bound usage counts. If no term matches, it returns a bounded catalog fallback instead of an empty dead end. With `mine=true`, the tool verifies the current GitHub token through `/user`, returns only releases attributed to that authenticated contributor, and summarizes their reported usage across immutable versions.
 - `get_shared_skill(skill_name, version, force_refresh)`: registry-whitelisted retrieval with SHA-256 and size verification.
 - `check_skill_updates(installed_versions, force_refresh)`: compares local versions or content digests with the active registry.
 - `submit_skill_evidence(...)`: authenticated, consent-gated, idempotent engineering evidence submission. The response reports the exact non-callable lifecycle state and stable public URL.
@@ -55,9 +55,11 @@ Clients must not construct artifact paths from user input. They select a release
 - Automated moderation produces `screened`, not `verified`. It covers all Agent-facing evidence fields and is a content-risk signal only; screened evidence is withheld from Agent consultation until trusted human review or immutable Skill publication.
 - Moderation failure is fail-closed for Skill candidacy.
 - Self-declared creator names do not establish publisher identity.
+- Contributor usage views are selected from the authenticated GitHub login and canonical registry originators/provenance; callers cannot supply another username.
 - A published Skill cannot override system or user instructions.
 - Agents must verify local applicability and obtain explicit user approval before external writes or destructive actions.
 - Outcome IDs are deterministic and ledger writes are idempotent. Reports remain evidence for review, never an automatic edit signal.
+- Usage counts mean trusted-review Outcome records only. They are an auditable lower bound, not a claim about total executions, downloads, or unique users.
 - Withdrawal preserves the immutable artifact for audit, marks the release inactive, and rolls `latest` back to the newest verified active release. If no active release remains, `latest` is `null`; the public audit page remains visible but installation is disabled.
 
 ## Verification Levels

--- a/docs/live-skills.md
+++ b/docs/live-skills.md
@@ -8,6 +8,7 @@ Every active Skill has:
 - a convenience mirror at `shared_skills/active/<name>/SKILL.md`;
 - an exact SHA-256 digest and byte size in `shared_skills/registry.json`;
 - an explicit verification level, provenance record, reviewer, and rollback state;
+- a reviewed Outcome count that provides an auditable lower bound on real use without telemetry;
 - one identity that future independent evidence can update through a new immutable version.
 
 The initial releases are labeled **maintainer-validated**. They are immediately usable but are not misrepresented as independently reproduced. `upload-debug-memory@1.0.1` is the first maintenance release and routes engineering fixes through the dedicated Skill evidence tool. Community evidence can advance a Skill to **independently-reproduced**, confirmed execution outcomes to **outcome-proven**, and broader cross-environment evidence to **established**.
@@ -30,6 +31,10 @@ MCP clients can call `list_shared_skills`, `get_shared_skill`, and `check_skill_
 Natural-language queries use tolerant ranked matching; a zero-match query returns a
 bounded catalog fallback rather than an empty dead end. Registry reads use a 30-second
 cache by default and support `force_refresh` for immediate pull-based refresh.
+Every catalog result includes approved Outcome counts. Authenticated contributors can
+call `list_shared_skills(mine=true)` to see only their canonical registry contributions
+and lifetime totals across immutable versions. These counts exclude discovery, downloads,
+and executions that were not submitted and approved.
 
 ## Living Skill #001
 

--- a/docs/project-memory-snapshot.md
+++ b/docs/project-memory-snapshot.md
@@ -2,6 +2,14 @@
 
 Last verified: 2026-07-27 (Asia/Shanghai)
 
+## Reviewed Shared Skill Usage Metrics
+
+- `list_shared_skills` now exposes per-Skill reviewed usage counts derived from the canonical registry Outcome counters. `usage` aggregates every immutable release, while `current_release_usage` reports the selected active version.
+- The counting basis is explicitly `approved-outcome-reports`. It is an auditable lower bound and excludes discovery, downloads, and executions that were not submitted and approved; Noosphere still has no silent usage telemetry.
+- `list_shared_skills(mine=true)` verifies the current GitHub token through the GitHub `/user` endpoint, filters against canonical registry originators/provenance, and returns an owner summary. Callers cannot provide another username or use a self-declared creator signature.
+- A real authenticated read against public registry revision `5` resolved owner `JinNing6`, returned 15 contributed Skills, and reported one approved use: one success and zero non-success reports for `public-artifact-runtime-smoke-gate`.
+- Verification includes 218 SDK tests, 24 repository tests, 102 Node workflow/supply-chain tests, registry/plugin validation, fatal Python lint, focused full Ruff checks, an MCP schema inspection showing 46 tools with the new optional `mine` field, and the authenticated remote read. This capability remains source-only until the still-pending `v0.9.1` GitHub/PyPI release.
+
 ## v0.9.1 Skill Evidence Flow — Merged and Live on `main`
 
 - PR #68 merged as `ca50c947d7a36840bed49ee045363b29dd82b573`. Source `main`, the SDK/server manifests, and both plugin manifests now declare `0.9.1`; no GitHub Release or PyPI `0.9.1` has been published, so the public package remains `noosphere-mcp==0.9.0`.

--- a/plugins/claude-noosphere/README.md
+++ b/plugins/claude-noosphere/README.md
@@ -31,7 +31,10 @@ When enabling the plugin:
 - `noosphere_repo`: defaults to `JinNing6/Noosphere`
 
 Focused discovery uses tolerant ranked matching and falls back to the bounded catalog
-instead of silently returning nothing. After a fix is verified, Claude asks for explicit
+instead of silently returning nothing. Catalog results include reviewed Outcome counts
+as a lower-bound usage metric. With a token, `list_shared_skills(mine=true)` verifies
+the current GitHub identity and returns that contributor's published Skills and lifetime
+reported-use totals. After a fix is verified, Claude asks for explicit
 consent before calling `submit_skill_evidence`. Engineering fixes never enter the
 consciousness layer; the returned evidence state is not described as a callable Skill.
 

--- a/plugins/noosphere/README.md
+++ b/plugins/noosphere/README.md
@@ -29,6 +29,9 @@ After installation, describe a real bug, failing test, build failure, package fa
 
 Anonymous registry discovery works without a token. Focused queries use tolerant ranked
 matching and fall back to the bounded catalog instead of silently returning nothing.
+Catalog results include reviewed Outcome counts as a lower-bound usage metric. With a
+token, `list_shared_skills(mine=true)` verifies the current GitHub identity and returns
+that contributor's published Skills and lifetime reported-use totals.
 Set `GITHUB_TOKEN` only for fresh Issue-layer reads or an explicitly approved public
 write. Verified engineering fixes use `submit_skill_evidence`; they never enter the
 consciousness layer. The token is forwarded to the Noosphere MCP server and is never

--- a/sdk/noosphere/engine/shared_skills.py
+++ b/sdk/noosphere/engine/shared_skills.py
@@ -73,6 +73,87 @@ def verify_skill_artifact(content: str, release: Mapping[str, Any]) -> bool:
     return len(encoded) == expected_size and hashlib.sha256(encoded).hexdigest() == expected_sha.lower()
 
 
+def summarize_release_usage(release: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the reviewed Outcome count for one immutable Skill release.
+
+    This is deliberately a lower-bound metric. Noosphere does not silently
+    track discovery, downloads, or unreported executions; only trusted-review
+    Outcome records are counted.
+    """
+    verification = release.get("verification", {})
+    if not isinstance(verification, Mapping):
+        raise ValueError("Invalid shared Skill verification metadata")
+
+    def _counter(name: str) -> int:
+        value = verification.get(name, 0)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"Invalid shared Skill Outcome counter: {name}")
+        return value
+
+    successful = _counter("verified_outcomes")
+    non_successful = _counter("failed_outcomes")
+    return {
+        "reported_usage_count": successful + non_successful,
+        "successful_usage_count": successful,
+        "non_successful_usage_count": non_successful,
+        "counting_basis": "approved-outcome-reports",
+        "lower_bound": True,
+    }
+
+
+def summarize_skill_usage(skill: Mapping[str, Any]) -> dict[str, Any]:
+    """Aggregate reviewed Outcome counts across every immutable release."""
+    releases = skill.get("releases", [])
+    if not isinstance(releases, list):
+        raise ValueError("Invalid shared Skill releases metadata")
+
+    usage = {
+        "reported_usage_count": 0,
+        "successful_usage_count": 0,
+        "non_successful_usage_count": 0,
+        "counting_basis": "approved-outcome-reports",
+        "lower_bound": True,
+    }
+    for release in releases:
+        if not isinstance(release, Mapping):
+            raise ValueError("Invalid shared Skill release metadata")
+        release_usage = summarize_release_usage(release)
+        for field in (
+            "reported_usage_count",
+            "successful_usage_count",
+            "non_successful_usage_count",
+        ):
+            usage[field] += release_usage[field]
+    return usage
+
+
+def is_release_originator(
+    skill: Mapping[str, Any],
+    release: Mapping[str, Any],
+    github_login: str,
+) -> bool:
+    """Return whether an authenticated GitHub login contributed this release."""
+    login = github_login.strip().casefold()
+    if not login:
+        return False
+
+    identities: list[Any] = []
+    originators = skill.get("originators", [])
+    if isinstance(originators, list):
+        identities.extend(originators)
+
+    provenance = release.get("provenance", {})
+    if isinstance(provenance, Mapping):
+        author = provenance.get("author")
+        if author:
+            identities.append(author)
+        authors = provenance.get("authors", [])
+        if isinstance(authors, list):
+            identities.extend(authors)
+
+    return any(isinstance(identity, str) and identity.strip().casefold() == login for identity in identities)
+
+
 def check_installed_skill_versions(
     registry: Mapping[str, Any],
     installed_versions: Mapping[str, str],

--- a/sdk/noosphere/noosphere_mcp.py
+++ b/sdk/noosphere/noosphere_mcp.py
@@ -55,7 +55,10 @@ from noosphere.engine.memory_integrity import (
 )
 from noosphere.engine.shared_skills import (
     check_installed_skill_versions,
+    is_release_originator,
     select_skill_release,
+    summarize_release_usage,
+    summarize_skill_usage,
     validate_skill_name,
     verify_skill_artifact,
 )
@@ -6229,12 +6232,26 @@ def _rank_shared_skill(skill: dict, query_tokens: set[str]) -> tuple[int, list[s
 async def list_shared_skills(
     query: str = "",
     force_refresh: bool = False,
+    mine: bool = False,
 ) -> str:
     """List approved dynamic Skills from the public Noosphere registry.
 
     Registry reads are anonymous. Only human-approved, active releases are
-    returned; unreviewed candidates never enter this interface.
+    returned; unreviewed candidates never enter this interface. Set ``mine``
+    to true to authenticate through GitHub and show only releases contributed
+    by the current token owner, together with reviewed usage counts.
     """
+    authenticated_owner = ""
+    if mine:
+        if not GITHUB_TOKEN:
+            return (
+                "❌ GITHUB_TOKEN not configured. Viewing your shared Skill usage "
+                "requires GitHub authentication."
+            )
+        authenticated_owner = await _get_authenticated_user()
+        if not authenticated_owner:
+            return "❌ Unable to verify the GitHub identity associated with GITHUB_TOKEN."
+
     try:
         registry = await _fetch_shared_skill_registry(force_refresh=force_refresh)
         query_tokens = _shared_skill_search_tokens(query)
@@ -6250,6 +6267,8 @@ async def list_shared_skills(
                 release = select_skill_release(registry, name)
             except (KeyError, ValueError):
                 continue
+            if mine and not is_release_originator(skill, release, authenticated_owner):
+                continue
             score, matched_terms = _rank_shared_skill(skill, query_tokens)
             candidates.append({
                 "name": name,
@@ -6261,16 +6280,18 @@ async def list_shared_skills(
                 "verification_level": release.get("verification", {}).get(
                     "level", "unclassified"
                 ),
+                "usage": summarize_skill_usage(skill),
+                "current_release_usage": summarize_release_usage(release),
                 "match_score": score,
                 "matched_terms": matched_terms,
             })
         if not query_tokens:
-            query_mode = "catalog"
+            query_mode = "owner-catalog" if mine else "catalog"
             visible = candidates
         else:
             visible = [candidate for candidate in candidates if candidate["match_score"] > 0]
             if visible:
-                query_mode = "ranked"
+                query_mode = "owner-ranked" if mine else "ranked"
                 visible.sort(
                     key=lambda candidate: (
                         -candidate["match_score"],
@@ -6279,13 +6300,37 @@ async def list_shared_skills(
                 )
                 visible = visible[:50]
             else:
-                query_mode = "catalog-fallback"
+                query_mode = "owner-catalog-fallback" if mine else "catalog-fallback"
                 visible = candidates[:50]
-        return json.dumps({
+        response = {
             "registry_revision": registry.get("revision", 0),
             "query_mode": query_mode,
+            "usage_measurement": {
+                "counting_basis": "approved-outcome-reports",
+                "lower_bound": True,
+                "excludes": [
+                    "discovery",
+                    "downloads",
+                    "unreported-executions",
+                ],
+            },
             "skills": visible,
-        }, ensure_ascii=False, indent=2)
+        }
+        if mine:
+            response["authenticated_owner"] = authenticated_owner
+            response["owner_summary"] = {
+                "shared_skill_count": len(visible),
+                "reported_usage_count": sum(
+                    item["usage"]["reported_usage_count"] for item in visible
+                ),
+                "successful_usage_count": sum(
+                    item["usage"]["successful_usage_count"] for item in visible
+                ),
+                "non_successful_usage_count": sum(
+                    item["usage"]["non_successful_usage_count"] for item in visible
+                ),
+            }
+        return json.dumps(response, ensure_ascii=False, indent=2)
     except (KeyError, RuntimeError, ValueError) as exc:
         return f"❌ Unable to read the shared Skill registry: {exc}"
 
@@ -6312,11 +6357,15 @@ async def get_shared_skill(
                 "❌ Shared Skill integrity verification failed. "
                 "The artifact was not returned to the Agent."
             )
+        usage = summarize_release_usage(release)
         return (
             f"SHARED SKILL: {skill_name}@{release['version']}\n"
             f"SHA-256: {artifact['sha256']}\n"
             f"Verification level: "
             f"{release.get('verification', {}).get('level', 'unclassified')}\n"
+            f"Reviewed usage reports: {usage['reported_usage_count']} "
+            f"(success: {usage['successful_usage_count']}, "
+            f"non-success: {usage['non_successful_usage_count']})\n"
             f"Registry revision: {registry.get('revision', 0)}\n\n"
             f"{content}"
         )

--- a/sdk/tests/test_shared_skills.py
+++ b/sdk/tests/test_shared_skills.py
@@ -9,7 +9,10 @@ from httpx import Response
 
 from noosphere.engine.shared_skills import (
     check_installed_skill_versions,
+    is_release_originator,
     select_skill_release,
+    summarize_release_usage,
+    summarize_skill_usage,
     validate_skill_name,
     verify_skill_artifact,
 )
@@ -113,6 +116,51 @@ def test_update_check_accepts_version_or_content_digest():
     assert by_digest["android-node-picking-recovery"]["status"] == "current"
 
 
+def test_usage_summary_is_a_reviewed_lower_bound_and_rejects_invalid_counters():
+    release = json.loads(json.dumps(REGISTRY["skills"][0]["releases"][0]))
+    release["verification"]["verified_outcomes"] = 3
+    release["verification"]["failed_outcomes"] = 2
+
+    usage = summarize_release_usage(release)
+
+    assert usage == {
+        "reported_usage_count": 5,
+        "successful_usage_count": 3,
+        "non_successful_usage_count": 2,
+        "counting_basis": "approved-outcome-reports",
+        "lower_bound": True,
+    }
+    release["verification"]["verified_outcomes"] = -1
+    with pytest.raises(ValueError, match="Outcome counter"):
+        summarize_release_usage(release)
+
+
+def test_skill_usage_aggregates_every_immutable_release():
+    skill = json.loads(json.dumps(REGISTRY["skills"][0]))
+    old_release = json.loads(json.dumps(skill["releases"][0]))
+    old_release["version"] = "0.9.0"
+    old_release["status"] = "withdrawn"
+    old_release["verification"]["verified_outcomes"] = 4
+    old_release["verification"]["failed_outcomes"] = 1
+    skill["releases"][0]["verification"]["verified_outcomes"] = 2
+    skill["releases"].insert(0, old_release)
+
+    usage = summarize_skill_usage(skill)
+
+    assert usage["reported_usage_count"] == 7
+    assert usage["successful_usage_count"] == 6
+    assert usage["non_successful_usage_count"] == 1
+
+
+def test_release_originator_uses_canonical_registry_identity_case_insensitively():
+    skill = REGISTRY["skills"][0]
+    release = skill["releases"][0]
+
+    assert is_release_originator(skill, release, "VALIDATOR-A") is True
+    assert is_release_originator(skill, release, "stranger") is False
+    assert is_release_originator(skill, release, "") is False
+
+
 @pytest.mark.asyncio
 @respx.mock
 async def test_list_and_get_shared_skills_allow_anonymous_verified_reads():
@@ -139,10 +187,62 @@ async def test_list_and_get_shared_skills_allow_anonymous_verified_reads():
     _invalidate_cache()
     assert "android-node-picking-recovery" in listed
     assert '"verification_level": "independently-reproduced"' in listed
+    assert '"reported_usage_count": 0' in listed
+    assert '"counting_basis": "approved-outcome-reports"' in listed
     assert SKILL_SHA in fetched
     assert "Verification level: independently-reproduced" in fetched
+    assert "Reviewed usage reports: 0" in fetched
     assert SKILL_CONTENT in fetched
     assert "Invalid Skill name" in rejected
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_list_my_shared_skills_binds_owner_to_authenticated_github_identity():
+    registry = json.loads(json.dumps(REGISTRY))
+    owned_release = registry["skills"][0]["releases"][0]
+    owned_release["verification"]["verified_outcomes"] = 2
+    owned_release["verification"]["failed_outcomes"] = 1
+    other_skill = json.loads(json.dumps(registry["skills"][0]))
+    other_skill["name"] = "unrelated-shared-skill"
+    other_skill["id"] = "noosphere:unrelated-shared-skill"
+    other_skill["originators"] = ["someone-else"]
+    other_skill["releases"][0]["provenance"]["authors"] = ["someone-else"]
+    other_skill["releases"][0]["artifact"]["path"] = "shared_skills/releases/1.0.0/unrelated-shared-skill/SKILL.md"
+    registry["skills"].append(other_skill)
+    registry_url = "https://api.github.com/repos/test_owner/test_repo/contents/shared_skills/registry.json"
+    respx.get("https://api.github.com/user").mock(return_value=Response(200, json={"login": "validator-a"}))
+    respx.get(registry_url).mock(return_value=Response(200, json={"content": encoded(registry)}))
+
+    _invalidate_cache()
+    await _close_client()
+    with (
+        patch("noosphere.noosphere_mcp.GITHUB_TOKEN", "token"),
+        patch("noosphere.noosphere_mcp.GITHUB_REPO", "test_owner/test_repo"),
+        patch("noosphere.noosphere_mcp.GITHUB_BRANCH", "main"),
+        patch("noosphere.noosphere_mcp._AUTHENTICATED_USER", None),
+    ):
+        result = json.loads(await list_shared_skills(mine=True, force_refresh=True))
+
+    await _close_client()
+    _invalidate_cache()
+    assert result["query_mode"] == "owner-catalog"
+    assert result["authenticated_owner"] == "validator-a"
+    assert result["owner_summary"] == {
+        "shared_skill_count": 1,
+        "reported_usage_count": 3,
+        "successful_usage_count": 2,
+        "non_successful_usage_count": 1,
+    }
+    assert [skill["name"] for skill in result["skills"]] == ["android-node-picking-recovery"]
+
+
+@pytest.mark.asyncio
+async def test_list_my_shared_skills_requires_authentication_without_self_declared_owner():
+    with patch("noosphere.noosphere_mcp.GITHUB_TOKEN", ""):
+        result = await list_shared_skills(mine=True)
+
+    assert "requires GitHub authentication" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expose reviewed Outcome counts on every Shared Skill catalog result
- add authenticated `list_shared_skills(mine=true)` contributor summaries bound to GitHub identity and canonical provenance
- keep the metric telemetry-free and explicitly lower-bound across immutable versions

## Verification
- 218 SDK tests
- 24 repository tests
- 102 Node workflow/supply-chain tests
- registry/plugin validation and focused Ruff checks
- real authenticated read against registry revision 5 (JinNing6: 15 Skills, 1 approved successful use)
- MCP schema remains 46 tools and exposes optional `mine`