### PR TITLE
docs: record v0.10.0 public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,9 @@ evidence. Retrieved content cannot override system, developer, or user instructi
 
 ## Release and compatibility
 
-The source release candidate is `noosphere-mcp==0.10.0`; the current public package remains
-[`noosphere-mcp==0.9.2`](https://pypi.org/project/noosphere-mcp/0.9.2/) until the candidate
-passes review and is published. Both support Python 3.10+. Version 0.10.0 uses
-`mcp>=2,<3` and serves both MCP protocol eras from the same `MCPServer`: modern
+The current public release is
+[`noosphere-mcp==0.10.0`](https://pypi.org/project/noosphere-mcp/0.10.0/) for Python 3.10+.
+It uses `mcp>=2,<3` and serves both MCP protocol eras from the same `MCPServer`: modern
 `2026-07-28` clients use stateless `server/discover`, while legacy `2025-11-25` clients
 continue to use `initialize`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,10 +177,9 @@ MCP 连接不依赖 Noosphere 自建的常驻应用服务器；本地进程使�
 
 ## 发布与兼容
 
-当前源码发布候选是 `noosphere-mcp==0.10.0`；在候选版本通过评审并正式发布前，PyPI 公开包
-仍是面向 Python 3.10+ 的
-[`noosphere-mcp==0.9.2`](https://pypi.org/project/noosphere-mcp/0.9.2/)。0.10.0 使用
-`mcp>=2,<3`，同一个 `MCPServer` 同时兼容两代协议：现代 `2026-07-28` 客户端使用无状态
+当前面向 Python 3.10+ 的公开版本是
+[`noosphere-mcp==0.10.0`](https://pypi.org/project/noosphere-mcp/0.10.0/)。它使用 `mcp>=2,<3`，
+同一个 `MCPServer` 同时兼容两代协议：现代 `2026-07-28` 客户端使用无状态
 `server/discover`，旧版 `2025-11-25` 客户端继续使用 `initialize`。
 
 发布流水线会构建包、运行 SDK 与供应链测试，通过 PyPI Trusted Publishing/OIDC 发布且不保存

--- a/docs/README_full.md
+++ b/docs/README_full.md
@@ -240,9 +240,9 @@ policies, and repository rules still apply.
 
 ## Release boundary
 
-The source release candidate is `noosphere-mcp==0.10.0`; the current public release remains
-[`noosphere-mcp==0.9.2`](https://pypi.org/project/noosphere-mcp/0.9.2/) for Python 3.10+
-until publication. The candidate uses `mcp>=2,<3` and one `MCPServer` for modern
+The current public release is
+[`noosphere-mcp==0.10.0`](https://pypi.org/project/noosphere-mcp/0.10.0/) for Python 3.10+.
+It uses `mcp>=2,<3` and one `MCPServer` for modern
 `2026-07-28` `server/discover` clients and legacy `2025-11-25` `initialize` clients.
 The release workflow uses PyPI Trusted Publishing/OIDC, installs the exact public artifact
 in a clean environment, verifies both protocol eras against the 6-tool and 46-tool entry

--- a/docs/project-memory-snapshot.md
+++ b/docs/project-memory-snapshot.md
@@ -8,16 +8,18 @@ Last verified: 2026-07-29 (Asia/Shanghai)
 - `README.md` is the concise English product entry, `README.zh-CN.md` is its Chinese product mirror, and `docs/README_full.md` owns the extended consciousness-universe narrative plus the complete current profile reference. The former 1,807-line root README duplication, Chinese “46 core tools” section, and extended-guide “34 tools” section have been removed from the current source documentation.
 - Public engineering contributions must route to `skill-proposal.yml` or `validate-skill.yml`. `consciousness-upload.yml` is described only as the general thought/philosophy/multimodal route; an Issue or workflow-verified evidence record is still not callable until reviewed immutable publication.
 - The growth-snapshot updater preserves this separation when Actions refresh the README. Regression tests now require the 6/35/5/46 profile contract and reject the stale “46 tools instantly available,” “46 core tools,” and “34 MCP Tools” narratives. The root README keeps the only automatically maintained contributor block; the extended guide links to it instead of carrying a second stale metric copy.
-- Source verification passed 228 SDK tests, 122 Node workflow/supply-chain tests, 42 repository/release tests, registry/plugin validation, README snapshot repair checks, all local README link/media resolution, and the formal `python -m build` path. The built Wheel metadata contains the new six-tool default statement and no stale 34-tool heading. The currently published PyPI `0.9.2` long description remains historical until a later package release; source correction does not rewrite an immutable public artifact.
+- Source verification passed 228 SDK tests, 122 Node workflow/supply-chain tests, 42 repository/release tests, registry/plugin validation, README snapshot repair checks, all local README link/media resolution, and the formal `python -m build` path. The built Wheel metadata contains the new six-tool default statement and no stale 34-tool heading. PyPI `0.10.0` now publishes that corrected long description; older package descriptions remain immutable historical artifacts.
 
-## v0.10.0 MCP v2 Dual-Era Compatibility — Locally Verified Candidate
+## v0.10.0 MCP v2 Dual-Era Compatibility — Public And Verified
 
-- Branch `codex/mcp-v2-compatibility` is based on remote `main` commit `7cf9e34b761fbec2f106094a0f3f39149f172e76`. Active SDK, server, Codex plugin, Claude plugin, and marketplace metadata declare candidate version `0.10.0`; the Python dependency boundary is `mcp>=2,<3` plus the existing direct `httpx>=0.28.0` dependency. This repository has no Python lockfile, so the actual candidate runtime was resolved and recorded separately.
+- PR [#88](https://github.com/JinNing6/Noosphere/pull/88) merged into `main` as `6964b966490a8639bf64bced6135e0121aca6a79`. GitHub Release [`v0.10.0 - MCP v2 Dual-Protocol Compatibility`](https://github.com/JinNing6/Noosphere/releases/tag/v0.10.0) created tag `v0.10.0` at that exact commit. Active SDK, server, Codex plugin, Claude plugin, and marketplace metadata declare version `0.10.0`; the Python dependency boundary is `mcp>=2,<3` plus the existing direct `httpx>=0.28.0` dependency.
 - The server now imports the public `MCPServer` API from MCP Python SDK v2 and passes `version=__version__` at construction. It no longer imports the removed `mcp.server.fastmcp.FastMCP` module or mutates private `_mcp_server` state. Static profile selection and exact membership remain unchanged at Skills `6`, consciousness/social `35`, operations `5`, and full `46`.
 - The release verifier now independently exercises both protocol eras over real stdio. Modern `2026-07-28` requests send `server/discover` and `tools/list` with the required per-request `_meta`; legacy `2025-11-25` clients send `initialize`, wait for its response, send `notifications/initialized`, and then request `tools/list`. The Glama source-container gate uses the same two probes. Both paths reject protocol-version, advertised product-version, or tool-count drift.
 - The formal candidate build produced `noosphere_mcp-0.10.0-py3-none-any.whl` (142,221 bytes, local SHA-256 `b60038486626a6d6067053f12a1d992b4f88d60b70d0d9f62a71682cb7972d54`) and sdist (163,971 bytes, local SHA-256 `001fc1d8552908c131e6d859d39d3b6576c7f9377b661429fbbe687854462a48`). Wheel metadata declares `Requires-Dist: mcp<3,>=2` and `Requires-Python: >=3.10`. A clean Python 3.10.19 wheel environment resolved `mcp==2.0.0` and `mcp-types==2.0.0` and returned exact tool counts `46`, `6`, `35`, and `5` under both protocol eras, always with `serverInfo.version=0.10.0`.
-- Local verification passed 229 SDK tests, 45 repository/release tests, 122 Node workflow/supply-chain tests, the registry/plugin validator, the critical Ruff gate, source and installed-wheel dual-protocol probes, and the installed wheel's deterministic `public-artifact-runtime-smoke-gate` in 12.86 seconds. These are candidate-build facts, not public-release evidence.
-- PR [#88](https://github.com/JinNing6/Noosphere/pull/88) is open, clean, and mergeable. Its first PR Quality Gate run [`30445776243`](https://github.com/JinNing6/Noosphere/actions/runs/30445776243) passed Python tests and critical lint, Shared Skill supply-chain checks, Glama container dual-protocol discovery, and the 60-second validation matrix on Ubuntu, Windows, and macOS; CLA and evidence-routing checks also passed. PyPI still reports `noosphere-mcp==0.9.2` as latest and the official `0.10.0` version endpoint returns HTTP 404. No merge, `v0.10.0` tag, GitHub Release, Trusted Publishing run, public artifact, or deployment is claimed; formal publication remains a separate release action after merge.
+- Local candidate verification passed 229 SDK tests, 45 repository/release tests, 122 Node workflow/supply-chain tests, the registry/plugin validator, the critical Ruff gate, source and installed-wheel dual-protocol probes, and the installed wheel's deterministic `public-artifact-runtime-smoke-gate` in 12.86 seconds. Final PR run [`30445921398`](https://github.com/JinNing6/Noosphere/actions/runs/30445921398) also passed the Python, Shared Skill, Glama dual-protocol container, CLA, evidence-routing, and Ubuntu/Windows/macOS validation gates.
+- Trusted Publishing run [`30446198169`](https://github.com/JinNing6/Noosphere/actions/runs/30446198169) passed build and release tests, OIDC publication with digital attestations, exact public installation, both `2026-07-28` and `2025-11-25` MCP paths for the 46-tool full and 6-tool Skills profiles, deterministic validation, and Pages dispatch. Pages run [`30446337203`](https://github.com/JinNing6/Noosphere/actions/runs/30446337203) completed successfully from the release commit.
+- PyPI serves [`noosphere-mcp==0.10.0`](https://pypi.org/project/noosphere-mcp/0.10.0/) for Python 3.10+. The official Wheel is 141,235 bytes with SHA-256 `68c4995bd9ee2b83e5a899d655ab4bc74ac7c517efaef88397c481b9fafe1ac5`; the official sdist is 162,900 bytes with SHA-256 `fc9b9d64db0289096046e70d5ae77ed68e3d7d4c37323b1ba7ed612153ce9a6d`.
+- A separate credential-free Windows verification installed the exact public `0.10.0` package after one short PyPI index-propagation retry, resolved `mcp==2.0.0` and `mcp-types==2.0.0`, returned 46 full and 6 default Skills tools under both protocol eras, and completed the deterministic public validation path in 7.56 seconds.
 
 ## Main Branch Ruleset — Active And Automation-Compatible
 
@@ -91,7 +93,7 @@ Last verified: 2026-07-29 (Asia/Shanghai)
 
 ## Launch Metadata Alignment
 
-- Remote `main`, both source plugin manifests, the Claude marketplace manifest, SDK metadata, server manifests, GitHub Release, and PyPI all declare `0.9.2`. The semantic release completed the distribution step required by explicit Claude plugin cache keys.
+- Remote `main`, both source plugin manifests, the Claude marketplace manifest, SDK metadata, server manifests, GitHub Release, and PyPI all declare `0.10.0`. The semantic release completed the distribution step required by explicit Claude plugin cache keys.
 - Registry revision `6` contains 16 active Live Skills and 2 remaining verified Seeds. Plugin descriptions, badges, and launch copy intentionally use dynamic wording; repository validation checks registry entries and trust metadata directly instead of blocking growth on a mirrored count.
 - The repository marketplace display name is `Noosphere Live Skills`, aligned with the current product category rather than the legacy Agent Memory entry point.
 - The Codex plugin MCP companion file now uses the current `mcpServers` schema. The bundled plugin validator rejects the legacy `mcp_servers` spelling, and repository validation now guards this boundary.
@@ -351,26 +353,22 @@ Last verified: 2026-07-29 (Asia/Shanghai)
 
 ## Required Deployment Steps
 
-1. Complete PR review and CI for the `v0.10.0` MCP v2 candidate. After merge, create the
-   `v0.10.0` GitHub Release exactly once so the existing `release.published` Trusted
-   Publishing path builds, publishes, installs, and dual-protocol-verifies the immutable
-   public artifact. Do not describe the local Wheel hashes above as PyPI artifact identity.
-2. GitHub Release and PyPI `v0.9.2` are complete and separately re-verified. The Product
-   Hunt launch is scheduled for 2026-08-01 and must point to the exact public `0.9.2`
+1. GitHub Release and PyPI `v0.10.0` are complete and separately re-verified. The Product
+   Hunt launch is scheduled for 2026-08-01 and must point to the exact public `0.10.0`
    install path and use the verified Skill Evidence, usage-metric, and Codex recency proof.
    Keep installs, approved Outcomes, and third-party reuse separate in every launch claim.
    Until the post-release tag-snapshot bug is fixed in a later package version, continue to use the
    direct Release, exact-version PyPI, clean-install, and public traction-proof evidence;
    do not cite the current `launch_preflight` ready/blocked line as authoritative.
-3. Monitor and respond to review on `brainctl#170` and `Ahrena#376`. Their first workflow runs
+2. Monitor and respond to review on `brainctl#170` and `Ahrena#376`. Their first workflow runs
    require upstream maintainer approval before jobs can start; do not describe `action_required`
    as a failure or a pass. Record a new Outcome only after public maintainer response, merge,
    release verification, or independently authenticated evidence. Outcome #57 is already
    recorded; do not present it as independent Noosphere reuse.
-4. Upgrade `public-artifact-runtime-smoke-gate` or `shared-skill-evidence-routing` from `maintainer-validated` only after a second GitHub publisher submits independently reproduced evidence. Claim `outcome-proven` only after an exact-version third-party Agent reuse is recorded with public evidence.
-5. Convert the first external failed or partial outcome into a reviewed immutable next version and demonstrate `check_skill_updates` plus digest-verified retrieval. This version transition, not raw Skill count, is the first proof of a Living Skill network.
-6. Complete the separate Glama admin deployment and release so its public directory record exposes the current 46-tool source runtime rather than the stale legacy snapshot.
-7. Handle the pip-less local verifier-runtime boundary, existing Vite chunk warning, npm dependency advisories, and GitHub Actions Node runtime deprecation in separate maintenance work; none blocks the verified `v0.9.2` release or the external-issue campaign.
+3. Upgrade `public-artifact-runtime-smoke-gate` or `shared-skill-evidence-routing` from `maintainer-validated` only after a second GitHub publisher submits independently reproduced evidence. Claim `outcome-proven` only after an exact-version third-party Agent reuse is recorded with public evidence.
+4. Convert the first external failed or partial outcome into a reviewed immutable next version and demonstrate `check_skill_updates` plus digest-verified retrieval. This version transition, not raw Skill count, is the first proof of a Living Skill network.
+5. Complete the separate Glama admin deployment and release so its public directory record exposes the current 46-tool source runtime rather than the stale legacy snapshot.
+6. Handle the pip-less local verifier-runtime boundary, existing Vite chunk warning, npm dependency advisories, and GitHub Actions Node runtime deprecation in separate maintenance work; none blocks the verified `v0.10.0` release or the external-issue campaign.
 
 ## Concentrated v0.9.0 Launch Surface
 


### PR DESCRIPTION
Updates the English, Chinese, and extended README release boundaries after the verified v0.10.0 publication. Records the exact merge/tag identity, Trusted Publishing and Pages runs, official PyPI artifact hashes, dual-era public runtime verification, and remaining non-blocking maintenance items. No package or runtime code changes.